### PR TITLE
Add 'mix exfmt.all' Task

### DIFF
--- a/lib/mix/tasks/exfmt.all.ex
+++ b/lib/mix/tasks/exfmt.all.ex
@@ -1,7 +1,9 @@
 defmodule Mix.Tasks.Exfmt.All do
   @moduledoc """
   Formats Elixir source code in specified directory recursively.
-      mix exfmt.all path/to/dir/
+  mix exfmt.all path/to/dir/
+  ## Command line options
+  * `--overwrite` Overwrite files that formatted by exfmt.
   """
 
   @shortdoc  "Format Elixir source code in specified directory."
@@ -21,15 +23,15 @@ defmodule Mix.Tasks.Exfmt.All do
   end
 
   def run(args) do
-    option_parser_options = [strict: [unsafe: :boolean]]
-    {_opts, [path], []} = OptionParser.parse(args, option_parser_options)
+    option_parser_options = [strict: [overwrite: :boolean]]
+    {opts, [path], []} = OptionParser.parse(args, option_parser_options)
     #TODO: Add code that checks path is a directory path.
     files = Path.join(path, "**/*.ex")
             |> Path.wildcard()
-    Enum.each(files, &format_dir(&1))
+    Enum.each(files, &format_dir(&1, opts))
   end
 
-  defp format_dir(path) do
+  defp format_dir(path, opts) do
     {:ok, source} = File.read(path)
     case Exfmt.format(source, 100) do
       {:ok, formatted} ->
@@ -39,8 +41,10 @@ defmodule Mix.Tasks.Exfmt.All do
           "#{path} does not formatted collectly!"
           |> red()
           |> IO.puts()
-          File.write!(path, formatted, [])
-          IO.write("#{path} is now formatted.")
+          if opts[:overwrite] do
+            File.write!(path, formatted, [])
+            IO.write("#{path} is now formatted.")
+          end
         end
       %SemanticsError{message: message} ->
         message

--- a/lib/mix/tasks/exfmt.all.ex
+++ b/lib/mix/tasks/exfmt.all.ex
@@ -1,9 +1,29 @@
 defmodule Mix.Tasks.Exfmt.All do
+  @moduledoc """
+  Formats Elixir source code in specified directory recursively.
+      mix exfmt.all path/to/dir/
+  """
+
+  @shortdoc  "Format Elixir source code in specified directory."
+  @usage """
+  USAGE:
+      mix exfmt.all path/to/dir/
+  """
   use Mix.Task
   alias Exfmt.{SyntaxError, SemanticsError}
+
+  @doc false
+  @spec run(OptionParser.argv) :: any
+  def run([]) do
+    @usage
+    |> red()
+    |> IO.write()
+  end
+
   def run(args) do
     option_parser_options = [strict: [unsafe: :boolean]]
     {_opts, [path], []} = OptionParser.parse(args, option_parser_options)
+    #TODO: Add code that checks path is a directory path.
     files = Path.join(path, "**/*.ex")
             |> Path.wildcard()
     Enum.each(files, &format_dir(&1))
@@ -20,6 +40,7 @@ defmodule Mix.Tasks.Exfmt.All do
           |> red()
           |> IO.puts()
           File.write!(path, formatted, [])
+          IO.write("#{path} is now formatted.")
         end
       %SemanticsError{message: message} ->
         message

--- a/lib/mix/tasks/exfmt.all.ex
+++ b/lib/mix/tasks/exfmt.all.ex
@@ -13,7 +13,14 @@ defmodule Mix.Tasks.Exfmt.All do
     {:ok, source} = File.read(path)
     case Exfmt.format(source, 100) do
       {:ok, formatted} ->
-        IO.write(formatted)
+        if source == formatted do
+          IO.write("#{path} is already formatted collectly")
+        else
+          "#{path} does not formatted collectly!"
+          |> red()
+          |> IO.puts()
+          File.write!(path, formatted, [])
+        end
       %SemanticsError{message: message} ->
         message
         |> red()

--- a/lib/mix/tasks/exfmt.all.ex
+++ b/lib/mix/tasks/exfmt.all.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.ExFmt.All do
+  use Mix.Task
+  alias Exfmt.{SyntaxError, SemanticsError}
+  def run([]) do
+    files = Path.join("./lib/", "**/*.ex")
+            |> Path.wildcard()
+    Enum.each(files, &format_file(&1))
+  end
+
+  defp format_file(path) do
+    with {:file, _, {:ok, source}} <- {:file, path, File.read(path)},
+         {:ok, formatted} <- Exfmt.format(source, 100) do
+      IO.write(formatted)
+    else
+      %SemanticsError{message: message} ->
+        message
+        |> red()
+        |> IO.puts
+
+      %SyntaxError{message: message} ->
+        message
+        |> red()
+        |> IO.puts
+    end
+  end
+
+  defp red(msg) do
+    [IO.ANSI.red, msg, IO.ANSI.reset]
+  end
+end

--- a/lib/mix/tasks/exfmt.all.ex
+++ b/lib/mix/tasks/exfmt.all.ex
@@ -1,29 +1,29 @@
-defmodule Mix.Tasks.ExFmt.All do
+defmodule Mix.Tasks.Exfmt.All do
   use Mix.Task
   alias Exfmt.{SyntaxError, SemanticsError}
-  def run([]) do
-    files = Path.join("./lib/", "**/*.ex")
+  def run(args) do
+    option_parser_options = [strict: [unsafe: :boolean]]
+    {_opts, [path], []} = OptionParser.parse(args, option_parser_options)
+    files = Path.join(path, "**/*.ex")
             |> Path.wildcard()
-    Enum.each(files, &format_file(&1))
+    Enum.each(files, &format_dir(&1))
   end
 
-  defp format_file(path) do
-    with {:file, _, {:ok, source}} <- {:file, path, File.read(path)},
-         {:ok, formatted} <- Exfmt.format(source, 100) do
-      IO.write(formatted)
-    else
+  defp format_dir(path) do
+    {:ok, source} = File.read(path)
+    case Exfmt.format(source, 100) do
+      {:ok, formatted} ->
+        IO.write(formatted)
       %SemanticsError{message: message} ->
         message
         |> red()
-        |> IO.puts
-
+        |> IO.puts()
       %SyntaxError{message: message} ->
         message
         |> red()
-        |> IO.puts
+        |> IO.puts()
     end
   end
-
   defp red(msg) do
     [IO.ANSI.red, msg, IO.ANSI.reset]
   end


### PR DESCRIPTION
Hi,
I Added 'exfmt.all' task for formatting source code in specified directory (recursively).

- Adding 'lib/mix/tasks/exfmt.all.ex'

# Feature

```
$ mix exfmt.all  lib/
$ lib/a.ex is  is already formatted collectly.
$ lib/b.ex does not formatted collectly! 
$ ...
$ ...
```

## Override Option

```
$ mix exfmt.all  lib/ --overwrite # Overwrite files that formatted by exfmt.
$ lib/a.ex is  is already formatted collectly.
$ lib/b.ex does not formatted collectly! 
$ lib/b.ex  is now formatted.
$ ...
$ ...
```

# Concerns

- Is this task should include 'unsafe' option?
-  Is `--override` option really safe?
- Is these output messages and input option name (e.g. "#{path} is already formatted collectly", --overwrite) apposite with this project?