### PR TITLE
Fix issues with surrounding whitespace on input

### DIFF
--- a/lib/exfmt.ex
+++ b/lib/exfmt.ex
@@ -20,7 +20,7 @@ defmodule Exfmt do
   Format a string of Elixir source code.
 
       iex> format("[1,2,3]")
-      {:ok, "[1, 2, 3]\n"}
+      {:ok, "[1, 2, 3]"}
 
   This function performs a check to ensure the input and output
   are semantically equivalent.
@@ -51,7 +51,7 @@ defmodule Exfmt do
   in the event of failure.
 
       iex> format!("[1,2,3]")
-      "[1, 2, 3]\n"
+      "[1, 2, 3]"
 
   This function performs a check to ensure the input and output
   are semantically equivalent.
@@ -73,7 +73,7 @@ defmodule Exfmt do
   Format a string of Elixir source code.
 
       iex> unsafe_format("[1,2,3]")
-      {:ok, "[1, 2, 3]\n"}
+      {:ok, "[1, 2, 3]"}
 
   Unlike `format/2` and `format!/2` this code does not compare
   the semantics of the input and the output, so if there is a
@@ -83,9 +83,20 @@ defmodule Exfmt do
   """
   @spec unsafe_format(String.t, integer) :: {:ok, String.t} | SyntaxError.t
   def unsafe_format(source, max_width \\ @max_width) do
+    leading_indent = leading_indent(source)
+    leading_whitespace = leading_whitespace(source, leading_indent)
+    trailing_whitespace = trailing_whitespace(source)
+
     with {:ok, tree} <- Code.string_to_quoted(source),
          {:ok, comments} <- Comment.extract_comments(source) do
-      {:ok, do_format(tree, comments, max_width)}
+      result =
+        tree
+        |> do_format(comments, max_width - leading_indent)
+        |> add_leading_indent(leading_indent)
+        |> add_trailing_whitespace(trailing_whitespace)
+        |> add_leading_whitespace(leading_whitespace)
+        |> strip_trailing_line_whitespace
+      {:ok, result}
     else
       {:error, error} ->
         SyntaxError.exception(error)
@@ -121,25 +132,64 @@ defmodule Exfmt do
     |> Ast.to_algebra(Context.new)
     |> Algebra.format(max_width)
     |> IO.chardata_to_string()
-    |> trim_whitespace()
-    |> append_newline()
   end
 
 
-  #
-  # FIXME: We shouldn't need to trim whitespace like this.
-  # Prevent the printer from inserting indentation with no
-  # content afterwards.
-  #
-  @trim_pattern ~r/\n +\n/
-  defp trim_whitespace(source) do
+  defp leading_indent(source, indent \\ 0)
+  defp leading_indent("\n" <> rest, indent) do
+    leading_indent(rest, indent)
+  end
+  defp leading_indent(" " <> rest, indent) do
+    leading_indent(rest, indent + 1)
+  end
+  defp leading_indent(_source, indent) do
+    indent
+  end
+
+
+  defp add_leading_indent(source, indent) do
     source
-    |> String.replace(@trim_pattern, "\n\n")
-    |> String.replace(@trim_pattern, "\n\n")
+    |> String.split("\n")
+    |> Enum.map(&add_indent_to_line(&1, indent))
+    |> Enum.join("\n")
   end
 
 
-  defp append_newline(source) do
-    source <> "\n"
+  defp add_indent_to_line(line, indent) do
+    String.duplicate(" ", indent) <> line
+  end
+
+
+  defp leading_whitespace(source, indent) do
+    regex_result = Regex.run(~r/\A(\s*)/m, source)
+    [capture | _rest] = regex_result || [""]
+    # remove leading indent from leading whitespace capture, as it gets added back anyway
+    capture_len = String.length(capture)
+    String.slice(capture, 0, capture_len - indent)
+  end
+
+
+  defp trailing_whitespace(source) do
+    regex_result = Regex.run(~r/(\n\s*)\Z/m, source)
+    [capture | _rest] = regex_result || [""]
+    capture
+  end
+
+
+  defp add_leading_whitespace(source, leading_whitespace) do
+    leading_whitespace <> source
+  end
+
+
+  defp add_trailing_whitespace(source, trailing_whitespace) do
+    source <> trailing_whitespace
+  end
+
+
+  defp strip_trailing_line_whitespace(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&String.rstrip/1)
+    |> Enum.join("\n")
   end
 end

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -3,37 +3,37 @@ defmodule Exfmt.Integration.BasicsTest do
   import Support.Integration
 
   test "ints" do
-    assert_format "0\n"
-    assert_format "1\n"
-    assert_format "2\n"
-    assert_format "-0\n"
-    assert_format "-1\n"
-    assert_format "-2\n"
+    assert_format "0"
+    assert_format "1"
+    assert_format "2"
+    assert_format "-0"
+    assert_format "-1"
+    assert_format "-2"
   end
 
   test "floats" do
-    "0.000" ~> "0.0\n"
-    "1.111" ~> "1.111\n"
-    "2.08" ~> "2.08\n"
-    "-0.000" ~> "-0.0\n"
-    "-0.123" ~> "-0.123\n"
-    "-1.123" ~> "-1.123\n"
-    "-2.123" ~> "-2.123\n"
+    "0.000" ~> "0.0"
+    assert_format "1.111"
+    assert_format "2.08"
+    "-0.000" ~> "-0.0"
+    "-0.123" ~> "-0.123"
+    "-1.123" ~> "-1.123"
+    "-2.123" ~> "-2.123"
   end
 
   test "atoms" do
-    assert_format ":ok\n"
-    assert_format ":\"hello-world\"\n"
-    assert_format ":\"[]\"\n"
-    assert_format ":_\n"
-    assert_format ~s(:"Elixir.Exfmt"\n)
+    assert_format ":ok"
+    assert_format ":\"hello-world\""
+    assert_format ":\"[]\""
+    assert_format ":_"
+    assert_format ~s(:"Elixir.Exfmt")
   end
 
   test "aliases" do
-    "String" ~> "String\n"
-    "My.String" ~> "My.String\n"
-    "App.Web.Controller" ~> "App.Web.Controller\n"
-    "__MODULE__.Helper" ~> "__MODULE__.Helper\n"
+    assert_format "String"
+    assert_format "My.String"
+    assert_format "App.Web.Controller"
+    assert_format "__MODULE__.Helper"
   end
 
   test "alias with quoted base mod" do
@@ -49,11 +49,11 @@ defmodule Exfmt.Integration.BasicsTest do
   end
 
   test "keyword lists" do
-    "[]" ~> "[]\n"
-    "[a: 1]" ~> "[a: 1]\n"
-    "[ b:  {} ]" ~> "[b: {}]\n"
-    "[a: 1, b: 2]" ~> "[a: 1, b: 2]\n"
-    "[{:a, 1}]" ~> "[a: 1]\n"
+    assert_format "[]"
+    assert_format "[a: 1]"
+    "[ b:  {} ]" ~> "[b: {}]"
+    assert_format "[a: 1, b: 2]"
+    "[{:a, 1}]" ~> "[a: 1]"
   end
 
   test "keyword lists with special atom keys" do
@@ -63,12 +63,12 @@ defmodule Exfmt.Integration.BasicsTest do
   end
 
   test "charlists" do
-    "''" ~> "[]\n"
-    "'a'" ~> "[97]\n" # TODO: Hmm...
+    "''" ~> "[]"
+    "'a'" ~> "[97]" # TODO: Hmm...
   end
 
   test "lists" do
-    "[ ]" ~> "[]\n"
+    "[ ]" ~> "[]"
     """
     [0,1,2,3,4,5,6,7,8,9,10,11,12]
     """ ~> """
@@ -146,22 +146,22 @@ defmodule Exfmt.Integration.BasicsTest do
 
 
   test "tuples" do
-    "{}" ~> "{}\n"
-    "{1}" ~> "{1}\n"
-    "{1,2}" ~> "{1, 2}\n"
-    "{1,2,3}" ~> "{1, 2, 3}\n"
+    assert_format "{}"
+    assert_format "{1}"
+    "{1,2}" ~> "{1, 2}"
+    "{1,2,3}" ~> "{1, 2, 3}"
   end
 
   test "variables" do
-    "some_var" ~> "some_var\n"
-    "_another_var" ~> "_another_var\n"
-    "thing1" ~> "thing1\n"
+    assert_format "some_var"
+    assert_format "_another_var"
+    assert_format "thing1"
   end
 
   test "module attributes" do
-    "@size" ~> "@size\n"
-    "@foo 1" ~> "@foo 1\n"
-    "@tag :skip" ~> "@tag :skip\n"
+    assert_format "@size"
+    assert_format "@foo 1"
+    assert_format "@tag :skip"
     """
     @sizes [1,2,3,4,5,6,7,8,9,10,11]
     """ ~> """
@@ -189,26 +189,32 @@ defmodule Exfmt.Integration.BasicsTest do
   end
 
   test "Access protocol" do
-    assert_format "keys[:name]\n"
-    assert_format "conn.assigns[:safe_mode_active]\n"
-    "some_list[\n   :name\n]" ~> "some_list[:name]\n"
+    assert_format "keys[:name]"
+    assert_format "conn.assigns[:safe_mode_active]"
+    """
+    some_list[
+    :name
+    ]
+    """ ~> """
+    some_list[:name]
+    """
   end
 
   test "maths" do
-    "1 + 2" ~> "1 + 2\n"
-    "1 - 2" ~> "1 - 2\n"
-    "1 * 2" ~> "1 * 2\n"
-    "1 / 2" ~> "1 / 2\n"
-    "1 * 2 + 3" ~> "1 * 2 + 3\n"
-    "1 + 2 * 3" ~> "1 + 2 * 3\n"
-    "(1 + 2) * 3" ~> "(1 + 2) * 3\n"
-    "(1 - 2) * 3" ~> "(1 - 2) * 3\n"
-    "1 / 2 + 3" ~> "1 / 2 + 3\n"
-    "1 + 2 / 3" ~> "1 + 2 / 3\n"
-    "(1 + 2) / 3" ~> "(1 + 2) / 3\n"
-    "(1 - 2) / 3" ~> "(1 - 2) / 3\n"
-    "1 * 2 / 3" ~> "1 * 2 / 3\n"
-    "1 / 2 * 3" ~> "1 / 2 * 3\n"
+    assert_format "1 + 2"
+    assert_format "1 - 2"
+    assert_format "1 * 2"
+    assert_format "1 / 2"
+    assert_format "1 * 2 + 3"
+    assert_format "1 + 2 * 3"
+    assert_format "(1 + 2) * 3"
+    assert_format "(1 - 2) * 3"
+    assert_format "1 / 2 + 3"
+    assert_format "1 + 2 / 3"
+    assert_format "(1 + 2) / 3"
+    assert_format "(1 - 2) / 3"
+    assert_format "1 * 2 / 3"
+    assert_format "1 / 2 * 3"
     """
     something_really_really_really_really_long + 2
     """ ~> """
@@ -218,49 +224,49 @@ defmodule Exfmt.Integration.BasicsTest do
   end
 
   test "list patterns" do
-    "[head1, head2|tail]" ~> "[head1, head2 | tail]\n"
+    "[head1, head2|tail]" ~> "[head1, head2 | tail]"
   end
 
   test "magic variables" do
-    "__MODULE__" ~> "__MODULE__\n"
-    "__CALLER__" ~> "__CALLER__\n"
+    assert_format "__MODULE__"
+    assert_format "__CALLER__"
   end
 
   test "booleans" do
-    "true" ~> "true\n"
-    "false" ~> "false\n"
+    assert_format "true"
+    assert_format "false"
   end
 
   test "||" do
-    "true || true" ~> "true || true\n"
+    assert_format "true || true"
   end
 
   test "&&" do
-    "true && true" ~> "true && true\n"
+    assert_format "true && true"
   end
 
   test "or" do
-    "true or true" ~> "true or true\n"
+    assert_format "true or true"
   end
 
   test "and" do
-    "true and true" ~> "true and true\n"
+    assert_format "true and true"
   end
 
   test "in" do
-    "x in [1, 2]" ~> "x in [1, 2]\n"
+    assert_format "x in [1, 2]"
   end
 
   test "~>" do
-    "x ~> [1, 2]" ~> "x ~> [1, 2]\n"
+    assert_format "x ~> [1, 2]"
   end
 
   test ">>>" do
-    "x >>> [1, 2]" ~> "x >>> [1, 2]\n"
+    assert_format "x >>> [1, 2]"
   end
 
   test "<>" do
-    "x <> y" ~> "x <> y\n"
+    assert_format "x <> y"
   end
 
   test "pipes |>" do

--- a/test/exfmt/integration/binary_test.exs
+++ b/test/exfmt/integration/binary_test.exs
@@ -10,8 +10,8 @@ defmodule Exfmt.Integration.BinaryTest do
     " "
     """
     # TODO: Use heredocs
-    ~s("\n") ~> ~s("\\n"\n)
-    ~s("""\nhello\n""") ~> ~s("hello\\n"\n)
+    ~s("\n") ~> ~s("\\n")
+    ~s("""\nhello\n""") ~> ~s("hello\\n")
   end
 
   test "string interpolation" do
@@ -33,12 +33,12 @@ defmodule Exfmt.Integration.BinaryTest do
   end
 
   test "empty binary" do
-    assert_format "<<>>\n"
+    assert_format "<<>>"
   end
 
   test "binaries with content" do
-    assert_format "<<200>>\n"
-    assert_format "<<1, 2, 3, 4>>\n"
+    assert_format "<<200>>"
+    assert_format "<<1, 2, 3, 4>>"
     assert_format """
     <<100,
       200,
@@ -52,8 +52,8 @@ defmodule Exfmt.Integration.BinaryTest do
   end
 
   test "binaries with sized content" do
-    assert_format "<<1::16>>\n"
-    assert_format "<<1::8 * 4>>\n"
+    assert_format "<<1::16>>"
+    assert_format "<<1::8 * 4>>"
     assert_format """
     <<690::bits - size(8 - 4) - unit(1),
       65>>
@@ -61,12 +61,12 @@ defmodule Exfmt.Integration.BinaryTest do
   end
 
   test "nested binaries" do
-    assert_format "<<(<<65>>), 65>>\n"
-    assert_format "<<65, (<<65>>)>>\n"
+    assert_format "<<(<<65>>), 65>>"
+    assert_format "<<65, (<<65>>)>>"
   end
 
   test "binary type" do
-    assert_format "@my_bin foo :: <<_::8, _::_ * 4>>\n"
+    assert_format "@my_bin foo :: <<_::8, _::_ * 4>>"
   end
 
   test "bit for comprehension" do

--- a/test/exfmt/integration/call_test.exs
+++ b/test/exfmt/integration/call_test.exs
@@ -3,10 +3,10 @@ defmodule Exfmt.Integration.CallTest do
   import Support.Integration
 
   test "function calls" do
-    assert_format "hello()\n"
-    assert_format "reverse \"hi\"\n"
-    assert_format "add 1, 2\n"
-    assert_format "add 1, 2, 3\n"
+    assert_format "hello()"
+    assert_format "reverse \"hi\""
+    assert_format "add 1, 2"
+    assert_format "add 1, 2, 3"
     """
     very_long_function_name_here :hello, :world
     """ ~> """
@@ -23,10 +23,10 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "anon function calls" do
-    assert_format "hello.()\n"
-    assert_format "reverse.(\"hi\")\n"
-    assert_format "add.(1, 2)\n"
-    assert_format "add.(1, 2, 3)\n"
+    assert_format "hello.()"
+    assert_format "reverse.(\"hi\")"
+    assert_format "add.(1, 2)"
+    assert_format "add.(1, 2, 3)"
     """
     very_long_function_name_here.(:hello, :world)
     """ ~> """
@@ -44,26 +44,26 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "qualified calls" do
-    "Process.get()" ~> "Process.get\n"
-    assert_format "Process.get\n"
-    assert_format "my_mod.get\n"
-    "my_mod.get(0)" ~> "my_mod.get 0\n"
-    assert_format "my_mod.get 0\n"
-    "String.length( my_string )" ~> "String.length my_string\n"
-    assert_format ":lists.reverse my_list\n"
+    "Process.get()" ~> "Process.get"
+    assert_format "Process.get"
+    assert_format "my_mod.get"
+    "my_mod.get(0)" ~> "my_mod.get 0"
+    assert_format "my_mod.get 0"
+    "String.length( my_string )" ~> "String.length my_string"
+    assert_format ":lists.reverse my_list"
   end
 
   test "calls with keyword args" do
-    "hello(foo: 1)" ~> "hello foo: 1\n"
-    "hello([foo: 1])" ~> "hello foo: 1\n"
-    "hello([  foo:   1])" ~> "hello foo: 1\n"
+    "hello(foo: 1)" ~> "hello foo: 1"
+    "hello([foo: 1])" ~> "hello foo: 1"
+    "hello([  foo:   1])" ~> "hello foo: 1"
   end
 
   test "require" do
-    assert_format "require Foo\n"
-    "require(Foo)" ~> "require Foo\n"
-    "require    Foo" ~> "require Foo\n"
-    assert_format "require Foo.Bar\n"
+    assert_format "require Foo"
+    "require(Foo)" ~> "require Foo"
+    "require    Foo" ~> "require Foo"
+    assert_format "require Foo.Bar"
     """
     require Really.Long.Module.Name, Another.Really.Long.Module.Name
     """ ~> """
@@ -73,10 +73,10 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "import" do
-    assert_format "import Foo\n"
-    "import(Foo)" ~> "import Foo\n"
-    "import    Foo" ~> "import Foo\n"
-    "import Foo.Bar" ~> "import Foo.Bar\n"
+    assert_format "import Foo"
+    "import(Foo)" ~> "import Foo"
+    "import    Foo" ~> "import Foo"
+    "import Foo.Bar" ~> "import Foo.Bar"
     """
     import Really.Long.Module.Name, Another.Really.Long.Module.Name
     """ ~> """
@@ -93,12 +93,12 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "alias" do
-    assert_format "alias Foo\n"
-    "alias(Foo)" ~> "alias Foo\n"
-    "alias    Foo" ~> "alias Foo\n"
-    assert_format "alias Foo.Bar\n"
-    assert_format "alias String, as: S\n"
-    "alias Element.{Storm,Earth,Fire}" ~> "alias Element.{Storm, Earth, Fire}\n"
+    assert_format "alias Foo"
+    "alias(Foo)" ~> "alias Foo"
+    "alias    Foo" ~> "alias Foo"
+    assert_format "alias Foo.Bar"
+    assert_format "alias String, as: S"
+    "alias Element.{Storm,Earth,Fire}" ~> "alias Element.{Storm, Earth, Fire}"
     """
     alias Element.{Storm,Earth,Fire,Nature,Courage,Heart}
     """ ~> """
@@ -109,38 +109,38 @@ defmodule Exfmt.Integration.CallTest do
                    Courage,
                    Heart}
     """
-    assert_format "alias Really.Long.Module.Name.That.Does.Not.Fit.In.Width\n"
+    assert_format "alias Really.Long.Module.Name.That.Does.Not.Fit.In.Width"
   end
 
   test "doctest" do
-    assert_format "doctest Foo\n"
+    assert_format "doctest Foo"
   end
 
   test "defstruct" do
-    assert_format "defstruct attrs\n"
-    assert_format "defstruct []\n"
-    assert_format "defstruct [:size, :age]\n"
-    "defstruct [size: 1, age: 2]" ~> "defstruct size: 1, age: 2\n"
+    assert_format "defstruct attrs"
+    assert_format "defstruct []"
+    assert_format "defstruct [:size, :age]"
+    "defstruct [size: 1, age: 2]" ~> "defstruct size: 1, age: 2"
   end
 
   test "use" do
-    assert_format "use ExUnit.Case, async: true\n"
+    assert_format "use ExUnit.Case, async: true"
   end
 
   test "send" do
-    assert_format "send my_pid, :hello\n"
+    assert_format "send my_pid, :hello"
   end
 
   test "call qualified by atom from another call" do
-    assert_format "Mix.shell.info :ok\n"
+    assert_format "Mix.shell.info :ok"
   end
 
   test "call with keyword list not as last arg" do
-    assert_format "print_tree [normal: app], opts\n"
+    assert_format "print_tree [normal: app], opts"
   end
 
   test "unquoted function name call" do
-    assert_format "unquote(callback).()\n"
+    assert_format "unquote(callback).()"
   end
 
   test "call with arg with do block" do

--- a/test/exfmt/integration/comments_test.exs
+++ b/test/exfmt/integration/comments_test.exs
@@ -60,6 +60,7 @@ defmodule Exfmt.Integration.CommentsTest do
     """ ~> """
     call arg()
     # Hello
+
     """
   end
 

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -3,28 +3,28 @@ defmodule Exfmt.Integration.FnTest do
   import Support.Integration
 
   test "captured functions" do
-    "&inspect/1" ~> "&inspect/1\n"
-    "&inspect(&1)" ~> "&inspect(&1)\n"
-    "&merge(&2, &1)" ~> "&merge(&2, &1)\n"
+    assert_format "&inspect/1"
+    assert_format "&inspect(&1)"
+    assert_format "&merge(&2, &1)"
   end
 
   test "captured infix operators" do
-    "&(&2 + &1)" ~> "& &2 + &1\n"
-    "(& &1.name)" ~> "& &1.name\n"
+    "&(&2 + &1)" ~> "& &2 + &1"
+    "(& &1.name)" ~> "& &1.name"
   end
 
   test "captured qualified function" do
-    assert_format "&A.info/0\n"
+    assert_format "&A.info/0"
   end
 
   test "calling captured functions" do
-    "(&inspect/1).()" ~> "(&inspect/1).()\n"
-    "(&(&1 <> x)).()" ~> "(& &1 <> x).()\n"
+    assert_format "(&inspect/1).()"
+    "(&(&1 <> x)).()" ~> "(& &1 <> x).()"
   end
 
   test "fn" do
-    assert_format "fn-> :ok end\n"
-    assert_format "fn(x) -> x end\n"
+    assert_format "fn-> :ok end"
+    assert_format "fn(x) -> x end"
     """
     fn(x) -> y = x + x; y end
     """ ~> """
@@ -68,15 +68,15 @@ defmodule Exfmt.Integration.FnTest do
   end
 
   test "captured map update fn" do
-    assert_format "& %{&1 | state: :ok}\n"
+    assert_format "& %{&1 | state: :ok}"
   end
 
   test "captured identity" do
-    assert_format "& &1\n"
+    assert_format "& &1"
   end
 
   test "captured Access" do
-    assert_format "& &1[:size]\n"
+    assert_format "& &1[:size]"
   end
 
   test "multi-arity fun with when guard" do

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -3,29 +3,29 @@ defmodule Exfmt.Integration.MapTest do
   import Support.Integration
 
   test "maps" do
-    "%{}" ~> "%{}\n"
-    "%{a: 1}" ~> "%{a: 1}\n"
-    "%{:a => 1}" ~> "%{a: 1}\n"
-    "%{1 => 1}" ~> "%{1 => 1}\n"
-    "%{1 => 1, 2 => 2}" ~> "%{1 => 1, 2 => 2}\n"
+    assert_format "%{}"
+    assert_format "%{a: 1}"
+    "%{:a => 1}" ~> "%{a: 1}"
+    assert_format "%{1 => 1}"
+    assert_format "%{1 => 1, 2 => 2}"
   end
 
   test "map upsert %{map | key: value}" do
-    "%{map | key: value}" ~> "%{map | key: value}\n"
+    assert_format "%{map | key: value}"
   end
 
   test "chained map get" do
-    assert_format "map.key.another.a_third\n"
+    assert_format "map.key.another.a_third"
   end
 
   test "qualified call into map get" do
-    assert_format "Map.new.key\n"
+    assert_format "Map.new.key"
   end
 
   test "structs" do
-    assert_format "%Person{}\n"
-    assert_format "%Person{age: 1}\n"
-    "%Person{timmy | age: 1}" ~> "%Person{timmy | age: 1}\n"
+    assert_format "%Person{}"
+    assert_format "%Person{age: 1}"
+    assert_format "%Person{timmy | age: 1}"
     """
     %LongerNamePerson{timmy | name: "Timmy", age: 1}
     """ ~> """
@@ -33,16 +33,16 @@ defmodule Exfmt.Integration.MapTest do
                       name: "Timmy",
                       age: 1}
     """
-    assert_format "%Inspect.Opts{}\n"
+    assert_format "%Inspect.Opts{}"
   end
 
   test "__MODULE__ structs" do
-    assert_format "%__MODULE__.Person{}\n"
-    assert_format "%__MODULE__{debug: true}\n"
+    assert_format "%__MODULE__.Person{}"
+    assert_format "%__MODULE__{debug: true}"
   end
 
   test "variable type struct" do
-    assert_format "%struct_type{}\n"
+    assert_format "%struct_type{}"
   end
 
   test "keys with spaces" do

--- a/test/exfmt/integration/sigil_test.exs
+++ b/test/exfmt/integration/sigil_test.exs
@@ -3,29 +3,29 @@ defmodule Exfmt.Integration.SigilTest do
   import Support.Integration
 
   test "r sigils" do
-    assert_format "~r/hello/\n"
-    assert_format "~r/hello/ugi\n"
-    assert_format "~R/hello/\n"
-    assert_format "~R/hello/ugi\n"
-    "~r(hello)" ~> "~r/hello/\n"
-    "~r[hello]" ~> "~r/hello/\n"
-    "~r{hello}" ~> "~r/hello/\n"
-    ~S"~r/\//" ~> "~r(/)\n"
+    assert_format "~r/hello/"
+    assert_format "~r/hello/ugi"
+    assert_format "~R/hello/"
+    assert_format "~R/hello/ugi"
+    "~r(hello)" ~> "~r/hello/"
+    "~r[hello]" ~> "~r/hello/"
+    "~r{hello}" ~> "~r/hello/"
+    ~S"~r/\//" ~> "~r(/)"
   end
 
   test "r sigil 2" do
-    ~S"~r/\/()/" ~> ~S"~r(/(\))" <> "\n"
+    ~S"~r/\/()/" ~> ~S"~r(/(\))" <> ""
   end
 
   test "s sigils" do
-    assert_format ~s[~s(hello)\n]
-    ~S(~s"hello") ~> ~s[~s(hello)\n]
-    ~S(~s/hello/ugi) ~> ~s[~s(hello)ugi\n]
-    ~S(~S"hello") ~> ~s[~S(hello)\n]
-    ~S(~S/hello/ugi) ~> ~s[~S(hello)ugi\n]
-    ~S(~s[hello]) ~> ~s[~s(hello)\n]
-    ~S(~s{hello}) ~> ~s[~s(hello)\n]
-    ~S[~s"()"] ~> ~s{~s[()]\n}
+    assert_format ~s[~s(hello)]
+    ~S(~s"hello") ~> ~s[~s(hello)]
+    ~S(~s/hello/ugi) ~> ~s[~s(hello)ugi]
+    ~S(~S"hello") ~> ~s[~S(hello)]
+    ~S(~S/hello/ugi) ~> ~s[~S(hello)ugi]
+    ~S(~s[hello]) ~> ~s[~s(hello)]
+    ~S(~s{hello}) ~> ~s[~s(hello)]
+    ~S[~s"()"] ~> ~s{~s[()]}
   end
 
   test "multi-line sigils" do

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -3,8 +3,8 @@ defmodule Exfmt.Integration.TypespecTest do
   import Support.Integration
 
   test "@spec" do
-    "@spec bar() :: 1" ~> "@spec bar() :: 1\n"
-    "@spec ok :: :ok" ~> "@spec ok :: :ok\n"
+    "@spec bar() :: 1" ~> "@spec bar() :: 1"
+    "@spec ok :: :ok" ~> "@spec ok :: :ok"
     """
     @spec run(String.t, [tern]) :: atom
     """ ~> """

--- a/test/exfmt/integration/whitespace_test.exs
+++ b/test/exfmt/integration/whitespace_test.exs
@@ -1,0 +1,53 @@
+defmodule Exfmt.Integration.WhitespaceTest do
+  use ExUnit.Case
+  import Support.Integration
+
+  test "one trailing newline" do
+    assert_format "[1, 2, 3]\n"
+  end
+
+  test "multiple trailing newlines" do
+    assert_format "[1, 2, 3]\n\n\n"
+  end
+
+  test "no trailing newline" do
+    assert_format "[1, 2, 3]"
+  end
+
+  test "leading indent, one line of code" do
+    assert_format "  [1, 2, 3]\n"
+  end
+
+  test "leading indent, multiple lines of code" do
+    assert_format """
+      fn(x) ->
+        y = x + x
+        y
+      end
+    """
+  end
+
+  test "multiple lines of code padded with blank lines" do
+    assert_format """
+
+
+
+          fn(x) ->
+            y = x + x
+            y
+          end
+
+
+    """
+  end
+
+  test "wraps if leading indent + code width > max width" do
+    """
+            [100000000, 100000000, 100000000]
+    """ ~> """
+            [100000000,
+             100000000,
+             100000000]
+    """
+  end
+end

--- a/test/exfmt_test.exs
+++ b/test/exfmt_test.exs
@@ -4,7 +4,7 @@ defmodule ExfmtTest do
 
   describe "format/2" do
     test "formats valid source code" do
-      assert Exfmt.format("[1,2,3]") == {:ok, "[1, 2, 3]\n"}
+      assert Exfmt.format("[1,2,3]") == {:ok, "[1, 2, 3]"}
     end
 
     test "returns error on invalid syntax" do
@@ -17,7 +17,7 @@ defmodule ExfmtTest do
 
   describe "format!/2" do
     test "formats valid source code" do
-      assert Exfmt.format!("[1,2,3]") == "[1, 2, 3]\n"
+      assert Exfmt.format!("[1,2,3]") == "[1, 2, 3]"
     end
 
     test "throws on invalid syntax" do
@@ -30,11 +30,11 @@ defmodule ExfmtTest do
 
   describe "check/2" do
     test "ok for correctly formatted code" do
-      assert Exfmt.check("[1, 2, 3]\n") == :ok
+      assert Exfmt.check("[1, 2, 3]") == :ok
     end
 
     test "format_error for incorrectly formatted code" do
-      assert Exfmt.check("[1,\n2]\n") == {:format_error, "[1, 2]\n"}
+      assert Exfmt.check("[1,\n2]") == {:format_error, "[1, 2]"}
     end
 
     test "returns error on invalid syntax" do


### PR DESCRIPTION
In the process of getting exfmt into a state that's useful to my workflow, I had to make some changes so that I could pipe Elixir code into it on stdin and have it printed on stdout. (In Vim/Spacemacs, I want to type `:!mix exfmt` to format highlighted code.)

The biggest change I had to make for this to work was to ensure exfmt preserves the indent on the code, so that my freshly formatted code doesn't end up in column 1 in my text editor. It also now preserves newlines at the start and end of the input, so that formatting code in an editor doesn't have the side effect of deleting blank lines.

I noticed that this change seemed to tidy up a lot of unit tests, so I distilled this change into this PR for your consideration. :)