### PR TITLE
Enhanced CLI support

### DIFF
--- a/lib/exfmt/cli.ex
+++ b/lib/exfmt/cli.ex
@@ -1,0 +1,63 @@
+defmodule Exfmt.Cli do
+  defmodule Output do
+    defstruct [:stdout, :stderr, exit_code: 0]
+  end
+
+  @spec run(OptionParser.argv) :: %Output{}
+  def run(argv) do
+    argv
+    |> parse_argv
+    |> read_source
+    |> format
+    |> output
+  end
+
+  defp parse_argv(args) do
+    {switches, args, _errors} = OptionParser.parse(args, [strict: [unsafe: :boolean, stdin: :boolean]])
+    {Enum.into(switches, %{}), args}
+  end
+
+  defp read_source({%{stdin: true}=switches, args}) do
+    source =
+      case IO.read(:stdio, :all) do
+        {:error, reason} -> {:error, reason}
+        data -> {:ok, data}
+      end
+    {switches, args, source}
+  end
+  defp read_source({switches, [path]=args}) do
+    {switches, args, File.read(path)}
+  end
+
+  defp format({%{unsafe: true}, _args, {:ok, source}}) do
+    Exfmt.unsafe_format(source)
+  end
+  defp format({_switches, _args, {:ok, source}}) do
+    Exfmt.format(source)
+  end
+  defp format({switches, args, {:error, _reason}=error}) do
+    {switches, args, error}
+  end
+
+  defp output({:ok, formatted}) do
+    %Output{
+      exit_code: 0,
+      stdout: formatted,
+    }
+  end
+  defp output(%{__exception__: true}=exception) do
+    %Output{
+      exit_code: 1,
+      stderr: Exception.message(exception),
+    }
+  end
+  defp output({switches, args, {:error, reason}}) do
+    %Output{
+      exit_code: 1,
+      stderr: """
+        Error: #{:file.format_error(reason)}
+        Args: #{inspect switches} #{inspect args}
+      """,
+    }
+  end
+end

--- a/lib/mix/tasks/exfmt.ex
+++ b/lib/mix/tasks/exfmt.ex
@@ -13,10 +13,6 @@ defmodule Mix.Tasks.Exfmt do
 
   """
 
-  defmodule Action do
-    defstruct [:stdout, :stderr, exit_code: 0]
-  end
-
   @shortdoc  "Format Elixir source code"
   @usage """
   USAGE:
@@ -25,77 +21,24 @@ defmodule Mix.Tasks.Exfmt do
 
   use Mix.Task
 
+  alias Exfmt.Cli
+
   @doc false
   @spec run(OptionParser.argv) :: any
   def run([]) do
     Mix.Shell.IO.error(@usage)
   end
-
-  def run(args) do
-    args
-    |> process
+  def run(argv) do
+    argv
+    |> Cli.run()
     |> execute
   end
 
-  def process(args) do
-    args
-    |> parse
-    |> input
-    |> format
-    |> output
-  end
-
-  defp parse(args) do
-    {switches, args, _errors} = OptionParser.parse(args, [strict: [unsafe: :boolean, stdin: :boolean]])
-    {Enum.into(switches, %{}), args}
-  end
-
-  defp input({%{stdin: true}=switches, args}) do
-    source =
-      case IO.read(:stdio, :all) do
-        {:error, reason} -> {:error, reason}
-        data -> {:ok, data}
-      end
-    {switches, args, source}
-  end
-  defp input({switches, [path]=args}) do
-    {switches, args, File.read(path)}
-  end
-
-  defp format({%{unsafe: true}, _args, {:ok, source}}) do
-    Exfmt.unsafe_format(source)
-  end
-  defp format({_switches, _args, {:ok, source}}) do
-    Exfmt.format(source)
-  end
-  defp format({switches, args, {:error, _reason}=error}) do
-    {switches, args, error}
-  end
-
-  def output({:ok, formatted}) do
-    %Action{stdout: formatted}
-  end
-  def output(%{__exception__: true}=exception) do
-    %Action{
-      exit_code: 1,
-      stderr: Exception.message(exception),
-    }
-  end
-  def output({switches, args, {:error, reason}}) do
-    %Action{
-      exit_code: 1,
-      stderr: """
-        Error: #{:file.format_error(reason)}
-        Args: #{inspect switches} #{inspect args}
-      """,
-    }
-  end
-
-  def execute(%Action{exit_code: 1, stderr: stderr}) do
+  def execute(%Cli.Output{exit_code: 1, stderr: stderr}) do
     Mix.Shell.IO.error(stderr)
     System.halt(1)
   end
-  def execute(%Action{exit_code: 0, stdout: stdout}) do
+  def execute(%Cli.Output{exit_code: 0, stdout: stdout}) do
     IO.write(stdout)
   end
 end

--- a/test/exfmt/cli_test.exs
+++ b/test/exfmt/cli_test.exs
@@ -1,0 +1,38 @@
+defmodule Exfmt.CliTest do
+  use ExUnit.Case, async: true
+
+  describe "Cli run" do
+    test "path to unknown file" do
+      result = Exfmt.Cli.run(["unknown-path-here"])
+      assert result.stderr =~ "no such file or directory"
+      assert result.stderr =~ "unknown-path-here"
+    end
+
+    test "file with valid syntax" do
+      result = Exfmt.Cli.run(["priv/examples/ok.ex"])
+      assert result.stdout == ":ok\n"
+    end
+
+    test "file with syntax error" do
+      result = Exfmt.Cli.run(["priv/examples/syntax_error.ex"])
+      assert result.stderr =~ "Error: syntax error before"
+    end
+
+    test "stdin with valid syntax" do
+      provide_stdin(" :ok  ")
+      result = Exfmt.Cli.run(["--stdin"])
+      assert result.stdout == ":ok\n"
+    end
+
+    test "stdin with syntax error" do
+      provide_stdin(" - , = ")
+      result = Exfmt.Cli.run(["--stdin"])
+      assert result.stderr =~ "Error: syntax error before"
+    end
+  end
+
+  def provide_stdin(string) do
+    {:ok, fake_stdin} = StringIO.open(string)
+    Process.group_leader(self(), fake_stdin)
+  end
+end

--- a/test/mix/tasks/exfmt_test.exs
+++ b/test/mix/tasks/exfmt_test.exs
@@ -11,32 +11,14 @@ defmodule Mix.Tasks.ExfmtTest do
       assert io =~ "mix exfmt path/to/file.ex"
     end
 
-    test "path to unknown file" do
-      result = Mix.Tasks.Exfmt.process(["unknown-path-here"])
-      assert result.stderr =~ "no such file or directory"
-      assert result.stderr =~ "unknown-path-here"
-    end
-
-    test "file with syntax error" do
-      result = Mix.Tasks.Exfmt.process(["priv/examples/syntax_error.ex"])
-      assert result.stderr =~ "Error: syntax error before"
-    end
-
-    test "stdin with valid syntax" do
-      capture_io(" :ok ", fn ->
-        result = Mix.Tasks.Exfmt.process(["--stdin"])
-        assert result.stdout =~ ":ok\n"
-      end)
-    end
-
-    test "file with valid syntax via shell" do
+    test "file path" do
       io = capture_io(fn->
         Mix.Tasks.Exfmt.run(["priv/examples/ok.ex"])
       end)
       assert io == ":ok\n"
     end
 
-    test "stdin with valid syntax via shell" do
+    test "STDIN to STDOUT" do
       io = capture_io(" :ok ", fn->
         Mix.Tasks.Exfmt.run(["--stdin"])
       end)

--- a/test/mix/tasks/exfmt_test.exs
+++ b/test/mix/tasks/exfmt_test.exs
@@ -12,28 +12,31 @@ defmodule Mix.Tasks.ExfmtTest do
     end
 
     test "path to unknown file" do
-      io = capture_io(:stderr, fn->
-        Mix.Tasks.Exfmt.run(["unknown-path-here"])
-      end)
-      assert io =~ "no such file or directory"
-      assert io =~ "unknown-path-here"
+      result = Mix.Tasks.Exfmt.process(["unknown-path-here"])
+      assert result.stderr =~ "no such file or directory"
+      assert result.stderr =~ "unknown-path-here"
     end
 
     test "file with syntax error" do
-      io = capture_io(:stderr, fn->
-        Mix.Tasks.Exfmt.run(["priv/examples/syntax_error.ex"])
-      end)
-      assert io =~ "Error: syntax error before"
+      result = Mix.Tasks.Exfmt.process(["priv/examples/syntax_error.ex"])
+      assert result.stderr =~ "Error: syntax error before"
     end
 
-    test "file with valid syntax" do
+    test "stdin with valid syntax" do
+      capture_io(" :ok ", fn ->
+        result = Mix.Tasks.Exfmt.process(["--stdin"])
+        assert result.stdout =~ ":ok\n"
+      end)
+    end
+
+    test "file with valid syntax via shell" do
       io = capture_io(fn->
         Mix.Tasks.Exfmt.run(["priv/examples/ok.ex"])
       end)
       assert io == ":ok\n"
     end
 
-    test "stdin with valid syntax" do
+    test "stdin with valid syntax via shell" do
       io = capture_io(" :ok ", fn->
         Mix.Tasks.Exfmt.run(["--stdin"])
       end)

--- a/test/mix/tasks/exfmt_test.exs
+++ b/test/mix/tasks/exfmt_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.ExfmtTest do
 
   describe "mix exfmt" do
     test "with no args" do
-      io = capture_io(fn->
+      io = capture_io(:stderr, fn->
         Mix.Tasks.Exfmt.run([])
       end)
       assert io =~ "USAGE"
@@ -12,15 +12,15 @@ defmodule Mix.Tasks.ExfmtTest do
     end
 
     test "path to unknown file" do
-      io = capture_io(fn->
+      io = capture_io(:stderr, fn->
         Mix.Tasks.Exfmt.run(["unknown-path-here"])
       end)
-      assert io =~ "Error: No such file or directory"
+      assert io =~ "no such file or directory"
       assert io =~ "unknown-path-here"
     end
 
     test "file with syntax error" do
-      io = capture_io(fn->
+      io = capture_io(:stderr, fn->
         Mix.Tasks.Exfmt.run(["priv/examples/syntax_error.ex"])
       end)
       assert io =~ "Error: syntax error before"
@@ -29,6 +29,13 @@ defmodule Mix.Tasks.ExfmtTest do
     test "file with valid syntax" do
       io = capture_io(fn->
         Mix.Tasks.Exfmt.run(["priv/examples/ok.ex"])
+      end)
+      assert io == ":ok\n"
+    end
+
+    test "stdin with valid syntax" do
+      io = capture_io(" :ok ", fn->
+        Mix.Tasks.Exfmt.run(["--stdin"])
       end)
       assert io == ":ok\n"
     end


### PR DESCRIPTION
## Description

This PR adds in support for:
* Reading input from `STDIN` and writing it to `STDOUT` (https://github.com/lpil/exfmt/issues/23)
* Error messages are now sent to `STDERR` (https://github.com/lpil/exfmt/issues/24)
* Error states return with `exit_code` 1 (https://github.com/lpil/exfmt/issues/25)





## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
