### PR TITLE
Add Vim integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ The benefits of `exfmt`:
 ## Contents
 
 - [Usage](#usage)
+- [Editor integration](#editor-integration)
 - [Development](#development)
-
 
 ## Usage
 
@@ -78,6 +78,20 @@ The benefits of `exfmt`:
 # Preview the exfmt formatting of an Elixir source file
 mix exfmt path/to/file.ex
 ```
+
+## Editor integration
+
+**Vim using [Neoformat](https://github.com/sbdchd/neoformat)**:
+```viml
+let g:neoformat_elixir_exfmt = {
+      \ 'exe': 'mix',
+      \ 'args': ['exfmt']
+      \ }
+
+let g:neoformat_enabled_elixir = ['exfmt']
+```
+
+You can now format the current Elixir buffer using `:Neoformat`. For further instructions, please reference the Neoformat documentation.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ mix exfmt path/to/file.ex
 ```viml
 let g:neoformat_elixir_exfmt = {
       \ 'exe': 'mix',
-      \ 'args': ['exfmt']
+      \ 'args': ['exfmt', '--stdin'],
+      \ 'stdin': 1
       \ }
 
 let g:neoformat_enabled_elixir = ['exfmt']

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The benefits of `exfmt`:
 
 - [Usage](#usage)
 - [Editor integration](#editor-integration)
+  - [Vim using Neoformat](#vim-using-neoformat)
 - [Development](#development)
 
 ## Usage
@@ -81,7 +82,7 @@ mix exfmt path/to/file.ex
 
 ## Editor integration
 
-**Vim using [Neoformat](https://github.com/sbdchd/neoformat)**:
+### Vim using [Neoformat](https://github.com/sbdchd/neoformat)
 ```viml
 let g:neoformat_elixir_exfmt = {
       \ 'exe': 'mix',


### PR DESCRIPTION
Reference #26:
Add sample configuration for setting up `mix exfmt <file>` for Neoformat VIM plugin to README.

## Checklist

- [X] The change has been discussed in a GitHub issue.
- [ ] There are tests for the new functionality.
- [X] I agree to adhere to the code of conduct.
