### PR TITLE
Add space on "fn ->" on 0-arity functions

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -527,7 +527,7 @@ defmodule Exfmt.Ast.ToAlgebra do
   defp fn_head_algebra(args, ctx) do
     case args do
       [] ->
-        "fn->"
+        "fn ->"
 
       _ ->
         glue(call_to_algebra("fn", args, ctx), "->")

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -30,7 +30,7 @@ defmodule Exfmt.Integration.FnTest do
   end
 
   test "fn" do
-    assert_format "fn-> :ok end\n"
+    assert_format "fn -> :ok end\n"
     assert_format "fn(x) -> x end\n"
     """
     fn(x) -> y = x + x; y end


### PR DESCRIPTION
As discussed in #13 and lexmag/elixir-style-guide#30.

## Description
This changes the formatting for 0-arity anonymous functions to add a space between the `fn` keyword and the arrow `->` signifying the start of the function body.

**Old behavior:**
`Logger.info(fn-> "Logger message" end)`

**New behavior:**
`Logger.info(fn -> "Logger message" end)`

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
