### PR TITLE
Number underscores

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -376,7 +376,6 @@ defmodule Exfmt.Ast.ToAlgebra do
   #
   # Integers
   #
-  #
   def to_algebra(value, _ctx) when is_integer(value) do
     to_doc(value)
     |> insert_readability_underscores
@@ -389,8 +388,6 @@ defmodule Exfmt.Ast.ToAlgebra do
                                    is_binary(value) or is_number(value) do
     to_doc(value)
   end
-
-
 
   #
   # Atoms

--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -374,12 +374,23 @@ defmodule Exfmt.Ast.ToAlgebra do
   end
 
   #
+  # Integers
+  #
+  #
+  def to_algebra(value, _ctx) when is_integer(value) do
+    to_doc(value)
+    |> insert_readability_underscores
+  end
+
+  #
   # Strings, numbers, nil, booleans
   #
   def to_algebra(value, _ctx) when is_nil(value) or is_boolean(value) or
                                    is_binary(value) or is_number(value) do
     to_doc(value)
   end
+
+
 
   #
   # Atoms
@@ -849,5 +860,14 @@ defmodule Exfmt.Ast.ToAlgebra do
 
   defp struct_name_to_algebra(name, ctx) do
     to_algebra(name, ctx)
+  end
+
+  defp insert_readability_underscores(string_integer) do
+    string_integer
+    |> String.to_charlist
+    |> Enum.reverse
+    |> Enum.chunk_every(3, 3, [])
+    |> Enum.join("_")
+    |> String.reverse
   end
 end

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -11,6 +11,10 @@ defmodule Exfmt.Integration.BasicsTest do
     assert_format "-2\n"
   end
 
+  test "large ints" do
+    assert_format "10_000\n"
+  end
+
   test "floats" do
     "0.000" ~> "0.0\n"
     "1.111" ~> "1.111\n"

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -13,6 +13,12 @@ defmodule Exfmt.Integration.BasicsTest do
 
   test "large ints" do
     assert_format "10_000\n"
+    assert_format "100_000\n"
+    assert_format "1_000_000\n"
+
+    "1000" ~> "1_000\n"
+    "100000" ~> "100_000\n"
+    "1000000" ~> "1_000_000\n"
   end
 
   test "floats" do


### PR DESCRIPTION
## Description
Fixes that underscores in large integers were removed by formatting (as described in #39).
Also adds automatic formatting of such integers from the plain format (10000) into the encouraged readable format (10_000)

Very much open to feedback on the implementation!

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
