### PR TITLE
Add --check CLI flag

### DIFF
--- a/lib/exfmt/cli.ex
+++ b/lib/exfmt/cli.ex
@@ -26,7 +26,7 @@ defmodule Exfmt.Cli do
 
   defp parse_argv(args) do
     {switches, args, _errors} =
-      OptionParser.parse(args, strict: [unsafe: :boolean, stdin: :boolean])
+      OptionParser.parse(args, strict: [check: :boolean, unsafe: :boolean, stdin: :boolean])
     {Enum.into(switches, %{}), args}
   end
 
@@ -47,6 +47,9 @@ defmodule Exfmt.Cli do
     {switches, args, File.read(path)}
   end
 
+  defp format_source({%{check: true}, _args, {:ok, source}}) do
+    Exfmt.check source
+  end
 
   defp format_source({%{unsafe: true}, _args, {:ok, source}}) do
     Exfmt.unsafe_format source
@@ -63,6 +66,14 @@ defmodule Exfmt.Cli do
 
   defp construct_output({:ok, formatted}) do
     %Output{exit_code: 0, stdout: formatted}
+  end
+
+  defp construct_output(:ok) do
+    %Output{exit_code: 0}
+  end
+
+  defp construct_output({:format_error, _}) do
+    %Output{exit_code: 1}
   end
 
   defp construct_output(%{__exception__: true} = exception) do

--- a/lib/mix/tasks/exfmt.ex
+++ b/lib/mix/tasks/exfmt.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Exfmt do
 
   ## Command line options
 
+    * `--check` - Check if file is formatted, sets exit status to 1 if false
     * `--stdin` - Read from STDIN instead of a file
     * `--unsafe` - Disable the semantics check that verifies
       that `exmft` has not altered the semantic meaning of

--- a/priv/examples/format_me.ex
+++ b/priv/examples/format_me.ex
@@ -1,0 +1,1 @@
+%{foo: :bar,  \n ping:  "pong"}

--- a/test/exfmt/cli_test.exs
+++ b/test/exfmt/cli_test.exs
@@ -29,6 +29,39 @@ defmodule Exfmt.CliTest do
       result = Exfmt.Cli.run(["--stdin"])
       assert result.stderr =~ "Error: syntax error before"
     end
+
+    test "check with correctly formatted code" do
+      result = Exfmt.Cli.run(["--check", "priv/examples/ok.ex"])
+      assert result.exit_code == 0
+      assert result.stdout == nil
+    end
+
+    test "check with incorrectly formatted code" do
+      result = Exfmt.Cli.run(["--check", "priv/examples/format_me.ex"])
+      assert result.exit_code == 1
+      assert result.stdout == nil
+    end
+
+    test "stdin check with correctly formatted code" do
+      provide_stdin("[1, 2, 3]\n")
+      result = Exfmt.Cli.run(["--check", "--stdin"])
+      assert result.exit_code == 0
+      assert result.stdout == nil
+    end
+
+    test "stdin check with incorrectly formatted code" do
+      provide_stdin("[1,\n2]\n")
+      result = Exfmt.Cli.run(["--check", "--stdin"])
+      assert result.exit_code == 1
+      assert result.stdout == nil
+    end
+
+    test "check stdin with syntax error" do
+      provide_stdin(" - , = ")
+      result = Exfmt.Cli.run(["--stdin", "--check"])
+      assert result.exit_code == 1
+      assert result.stderr =~ "Error: syntax error before"
+    end
   end
 
   def provide_stdin(string) do


### PR DESCRIPTION
## Description

This pull request implements the `--check` CLI flag.

The exit status is set to `0` if already formatted and `1` otherwise.
Nothing is output to `stdout`.

Close #41

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
