### PR TITLE
Multiline map braces

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -112,6 +112,7 @@ defmodule Exfmt.Ast.ToAlgebra do
     |> glue("", body_doc)
     |> nest(2)
     |> glue("", "}")
+    |> group
   end
 
   #
@@ -212,6 +213,19 @@ defmodule Exfmt.Ast.ToAlgebra do
 
       {:.., _} ->
         concat(lhs, concat("..", rhs))
+
+      {:=, _} ->
+        case r do
+          # For Maps, we want to hold the opening brace next to the assignments
+          # even when space constraints force a line break
+          {:%{}, _, _} ->
+            lhs
+            |> space(to_string(op))
+            |> space(rhs)
+            |> group
+          _ ->
+            group(nest(glue(space(lhs, to_string(op)), rhs), 2))
+        end
 
       _ ->
         group(nest(glue(space(lhs, to_string(op)), rhs), 2))

--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -108,7 +108,10 @@ defmodule Exfmt.Ast.ToAlgebra do
   def to_algebra({:%{}, _, contents}, ctx) do
     new_ctx = Context.push_stack(ctx, :map)
     body_doc = map_body_to_algebra(contents, new_ctx)
-    group(nest(glue("%{", "", concat(body_doc, "}")), 2))
+    "%{"
+    |> glue("", body_doc)
+    |> nest(2)
+    |> glue("", "}")
   end
 
   #

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -10,6 +10,26 @@ defmodule Exfmt.Integration.MapTest do
     "%{1 => 1, 2 => 2}" ~> "%{1 => 1, 2 => 2}\n"
   end
 
+  test "multiline maps" do
+    assert_format """
+    %{
+      foo: 1,
+      bar: 2,
+      baz: 3,
+      somereallylongkey: 4
+    }
+    """
+
+    assert_format """
+    var = %{
+      foo: 1,
+      bar: 2,
+      baz: 3,
+      somereallylongkey: 4
+    }
+    """
+  end
+
   test "map upsert %{map | key: value}" do
     "%{map | key: value}" ~> "%{map | key: value}\n"
   end

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -20,6 +20,18 @@ defmodule Exfmt.Integration.MapTest do
     }
     """
 
+    """
+    %{foo: 1, bar: 2, baz: 3, somereallylongkey: 4, theotherkey: 5}
+    """ ~> """
+    %{
+      foo: 1,
+      bar: 2,
+      baz: 3,
+      somereallylongkey: 4,
+      theotherkey: 5
+    }
+    """
+
     assert_format """
     var = %{
       foo: 1,


### PR DESCRIPTION
## Description
Adds behavior for multiline maps as discussed in #44.
Also makes sure that when a multiline map is assigned to the variable, the opening brace remains next to the assignment, while wrapping the closing brace to the level of the assignment.

Demo gist: https://gist.github.com/jfornoff/ab669bb7a743d02a94f5261046ad2895

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
