### PR TITLE
[Bugfix] anonymous function arrows wrapping into the following line

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -158,7 +158,7 @@ defmodule Exfmt.Ast.ToAlgebra do
         line(nest(line(head, body_algebra), 2), "end")
 
       _single_expr ->
-        glue(glue(head, body_algebra), "end")
+        glue(nest(glue(head, body_algebra), 2), "end")
     end
   end
 
@@ -530,7 +530,7 @@ defmodule Exfmt.Ast.ToAlgebra do
         "fn ->"
 
       _ ->
-        glue(call_to_algebra("fn", args, ctx), "->")
+        space(call_to_algebra("fn", args, ctx), "->")
     end
   end
 

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -42,7 +42,7 @@ defmodule Exfmt.Integration.FnTest do
     """
   end
 
-  test "anonymous fn in long function calls" do
+  test "fn in long function calls" do
     """
     Enum.find([1,2,3,4], fn(num) -> rem(num, 2) == 0 end)
     """ ~> """
@@ -50,6 +50,14 @@ defmodule Exfmt.Integration.FnTest do
               fn(num) ->
                 rem(num, 2) == 0
               end
+    """
+
+    """
+    Logger.debug fn -> "Hey this is a long log message!" end
+    """ ~> """
+    Logger.debug fn ->
+                   "Hey this is a long log message!"
+                 end
     """
   end
 

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -42,6 +42,17 @@ defmodule Exfmt.Integration.FnTest do
     """
   end
 
+  test "anonymous fn in long function calls" do
+    """
+    Enum.find([1,2,3,4], fn(num) -> rem(num, 2) == 0 end)
+    """ ~> """
+    Enum.find [1, 2, 3, 4],
+              fn(num) ->
+                rem(num, 2) == 0
+              end
+    """
+  end
+
   test "multi-clause fn" do
     assert_format """
     fn


### PR DESCRIPTION
## Description
Fixes anonymous function arrows wrapping into the next line under some circumstances (as demonstrated in #13.

Formatting example demonstrating the change (taken from #13):
https://gist.github.com/anonymous/b68c178a749461585e53208753e06dc8#file-store_formatted-ex-L162

Might need followup issues for:
- [ ] Pipeline syntax is not wrapped correctly in anonymous functions (first argument is with the function head)
- [ ] We are not adhering to the [guidelines regarding parentheses around fn arguments](https://github.com/lexmag/elixir-style-guide#anonymous-fun-parens) - might need discussion
- [ ] (This is IMHO) I'd prefer multi-argument function calls to have parentheses around the arguments, current behavior is no parentheses

Any feedback, as always, very welcome :-)

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
