### PR TITLE
Remove parentheses around arguments in fn-definitions

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -472,6 +472,10 @@ defmodule Exfmt.Ast.ToAlgebra do
         arg_list = args_to_algebra(args, ctx, parens: args_with_block?, space: !args_with_block?)
         concat(name, nest(arg_list, :current))
 
+      %{stack: [:fn | _], args: args} ->
+        arg_list = args_to_algebra(args, ctx, parens: false)
+        space(name, nest(arg_list, :current))
+
       _ ->
         arg_list = args_to_algebra(args, ctx)
         concat(name, nest(arg_list, :current))

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -31,11 +31,11 @@ defmodule Exfmt.Integration.FnTest do
 
   test "fn" do
     assert_format "fn -> :ok end\n"
-    assert_format "fn(x) -> x end\n"
+    assert_format "fn x -> x end\n"
     """
-    fn(x) -> y = x + x; y end
+    fn x -> y = x + x; y end
     """ ~> """
-    fn(x) ->
+    fn x ->
       y = x + x
       y
     end
@@ -44,10 +44,10 @@ defmodule Exfmt.Integration.FnTest do
 
   test "fn in long function calls" do
     """
-    Enum.find([1,2,3,4], fn(num) -> rem(num, 2) == 0 end)
+    Enum.find([1,2,3,4], fn num -> rem(num, 2) == 0 end)
     """ ~> """
     Enum.find [1, 2, 3, 4],
-              fn(num) ->
+              fn num ->
                 rem(num, 2) == 0
               end
     """
@@ -107,7 +107,7 @@ defmodule Exfmt.Integration.FnTest do
 
   test "multi-arity fun with when guard" do
     assert_format """
-    fn(:ok, x) when is_map(x) -> x end
+    fn :ok, x when is_map(x) -> x end
     """
   end
 


### PR DESCRIPTION
## Description
As discussed in #48:
According to [style guide convention](https://github.com/lexmag/elixir-style-guide#anonymous-fun-parens), this removes parentheses around arguments of `fn` definitions.

Changes to tests show the corrected output style :-)

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
