### PR TITLE
Indent `when` guard clauses on the same level as the definition #50

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -553,7 +553,7 @@ defmodule Exfmt.Ast.ToAlgebra do
     {call_args, [guard]} = Enum.split(args, -1)
     args_doc = args_to_algebra(call_args, ctx, opts)
     guard_doc = to_algebra(guard, new_ctx)
-    [args_doc, group(nest(glue("", group(glue("when", guard_doc))), 1))]
+    [args_doc, group(nest(glue("", group(space("when", guard_doc))), 1))]
     |> concat()
   end
 

--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -544,7 +544,7 @@ defmodule Exfmt.Ast.ToAlgebra do
   #
   # TODO: The `space` and `parens` options are pretty grim.
   # Perhaps split this out into just forming of the arguments,
-  # and leave the wrapping of parems to another function.
+  # and leave the wrapping of parens to another function.
   #
   defp args_to_algebra(args, ctx, opts \\ [parens: true])
 
@@ -553,7 +553,7 @@ defmodule Exfmt.Ast.ToAlgebra do
     {call_args, [guard]} = Enum.split(args, -1)
     args_doc = args_to_algebra(call_args, ctx, opts)
     guard_doc = to_algebra(guard, new_ctx)
-    [args_doc, " when ", guard_doc]
+    [args_doc, group(nest(glue("", group(glue("when", guard_doc))), 1))]
     |> concat()
   end
 

--- a/test/exfmt/integration/def_test.exs
+++ b/test/exfmt/integration/def_test.exs
@@ -10,6 +10,19 @@ defmodule Exfmt.Integration.DefTest do
     """
   end
 
+  test "def with long guard" do
+    """
+    def one?(x) when x in [:one, "one", 1, "1"] do
+      true
+    end
+    """ ~> """
+    def one?(x)
+        when x in [:one, "one", 1, "1"] do
+      true
+    end
+    """
+  end
+
   test "def spacing" do
     assert_format """
     def one(1) do


### PR DESCRIPTION
## Description

I'm still learning my way around the codebase, so there may be a simpler way to accomplish this. Please let me know if that's the case. 

Also, I made sure this works with other calls (defmacro, etc), but wasn't sure if we should have specific tests for those cases as well.


## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.