### PR TITLE
Render parens on qualified zero arity function calls #58

### DIFF
--- a/lib/exfmt/context.ex
+++ b/lib/exfmt/context.ex
@@ -41,6 +41,6 @@ defmodule Exfmt.Context do
   end
 
   def stack_contains?(ctx, value) do
-    Enum.any?(ctx.stack, fn v -> v == value end)
+    Enum.member?(ctx.stack, value)
   end
 end

--- a/lib/exfmt/context.ex
+++ b/lib/exfmt/context.ex
@@ -39,4 +39,8 @@ defmodule Exfmt.Context do
   def push_stack(ctx, value) when value in @valid_layers do
     %{ctx | stack: [value | ctx.stack]}
   end
+
+  def stack_contains?(ctx, value) do
+    Enum.any?(ctx.stack, fn v -> v == value end)
+  end
 end

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -235,7 +235,7 @@ defmodule Exfmt.Integration.BasicsTest do
     """ ~> """
     1
     |> double()
-    |> Number.triple
+    |> Number.triple()
     """
   end
 

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -55,9 +55,7 @@ defmodule Exfmt.Integration.BasicsTest do
   end
 
   test "aliases with variable part" do
-    assert_format """
-    One.x.Three
-    """
+    "One.x.Three" ~> "One.x().Three\n"
   end
 
   test "keyword lists" do

--- a/test/exfmt/integration/call_test.exs
+++ b/test/exfmt/integration/call_test.exs
@@ -46,13 +46,14 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "qualified calls" do
-    "Process.get()" ~> "Process.get\n"
-    assert_format "Process.get\n"
+    "Process.get" ~> "Process.get()\n"
+    assert_format "Process.get()\n"
     assert_format "my_mod.get\n"
     "my_mod.get(0)" ~> "my_mod.get 0\n"
     assert_format "my_mod.get 0\n"
     "String.length( my_string )" ~> "String.length my_string\n"
     assert_format ":lists.reverse my_list\n"
+    ":my_mod.run" ~> ":my_mod.run()\n"
   end
 
   test "calls with keyword args" do
@@ -134,7 +135,7 @@ defmodule Exfmt.Integration.CallTest do
   end
 
   test "call qualified by atom from another call" do
-    assert_format "Mix.shell.info :ok\n"
+    "Mix.shell.info :ok" ~> "Mix.shell().info :ok\n"
   end
 
   test "call with keyword list not as last arg" do

--- a/test/exfmt/integration/call_test.exs
+++ b/test/exfmt/integration/call_test.exs
@@ -48,7 +48,7 @@ defmodule Exfmt.Integration.CallTest do
   test "qualified calls" do
     "Process.get" ~> "Process.get()\n"
     assert_format "Process.get()\n"
-    "my_mod.get" ~> "my_mod.get()\n"
+    assert_format "my_mod.get\n"
     "my_mod.get(0)" ~> "my_mod.get 0\n"
     assert_format "my_mod.get 0\n"
     "String.length( my_string )" ~> "String.length my_string\n"

--- a/test/exfmt/integration/call_test.exs
+++ b/test/exfmt/integration/call_test.exs
@@ -48,7 +48,7 @@ defmodule Exfmt.Integration.CallTest do
   test "qualified calls" do
     "Process.get" ~> "Process.get()\n"
     assert_format "Process.get()\n"
-    assert_format "my_mod.get\n"
+    "my_mod.get" ~> "my_mod.get()\n"
     "my_mod.get(0)" ~> "my_mod.get 0\n"
     assert_format "my_mod.get 0\n"
     "String.length( my_string )" ~> "String.length my_string\n"

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -13,7 +13,7 @@ defmodule Exfmt.Integration.FnTest do
   end
 
   test "captured &1.prop" do
-    "(& &1.name)" ~> "& &1.name\n"
+    "(& &1.name)" ~> "& &1.name()\n"
   end
 
   test "captured &&/2" do

--- a/test/exfmt/integration/fn_test.exs
+++ b/test/exfmt/integration/fn_test.exs
@@ -13,7 +13,7 @@ defmodule Exfmt.Integration.FnTest do
   end
 
   test "captured &1.prop" do
-    "(& &1.name)" ~> "& &1.name()\n"
+    "(& &1.name)" ~> "& &1.name\n"
   end
 
   test "captured &&/2" do

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -51,7 +51,7 @@ defmodule Exfmt.Integration.MapTest do
   end
 
   test "qualified call into map get" do
-    assert_format "Map.new.key\n"
+    "Map.new.key" ~> "Map.new().key\n"
   end
 
   test "structs" do

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -47,11 +47,11 @@ defmodule Exfmt.Integration.MapTest do
   end
 
   test "chained map get" do
-    "map.key.another.a_third" ~> "map.key().another().a_third()\n"
+    assert_format "map.key.another.a_third\n"
   end
 
   test "qualified call into map get" do
-    "Map.new.key" ~> "Map.new().key()\n"
+    "Map.new.key" ~> "Map.new().key\n"
   end
 
   test "structs" do

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -47,11 +47,11 @@ defmodule Exfmt.Integration.MapTest do
   end
 
   test "chained map get" do
-    assert_format "map.key.another.a_third\n"
+    "map.key.another.a_third" ~> "map.key().another().a_third()\n"
   end
 
   test "qualified call into map get" do
-    "Map.new.key" ~> "Map.new().key\n"
+    "Map.new.key" ~> "Map.new().key()\n"
   end
 
   test "structs" do

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -19,15 +19,13 @@ defmodule Exfmt.Integration.TypespecTest do
     """
     @spec start_link(module(), term(number), Keyword.t()) :: on_start()
     """ ~> """
-    @spec start_link(module,
+    @spec start_link(module(),
                      term(number),
                      Keyword.t)
-    :: on_start
+    :: on_start()
     """
-    """
+    assert_format """
     @spec break() :: doc_break()
-    """ ~> """
-    @spec break() :: doc_break
     """
   end
 

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -16,6 +16,19 @@ defmodule Exfmt.Integration.TypespecTest do
     @spec run(String.t)
     :: atom | String.t | :hello
     """
+    """
+    @spec start_link(module(), term(number), Keyword.t()) :: on_start()
+    """ ~> """
+    @spec start_link(module,
+                     term(number),
+                     Keyword.t)
+    :: on_start
+    """
+    """
+    @spec break() :: doc_break()
+    """ ~> """
+    @spec break() :: doc_break
+    """
   end
 
   test "@spec 2" do


### PR DESCRIPTION
## Description

Adds parenthesis to zero arity calls. It currently handles three scenarios:

1. Zero arity qualified function calls to an alias: ```Mix.env()```
2. Zero arity qualified function calls to an atom: ```:random.uniform()```
3. Zero arity types: ```@spec start_link(module, term(number), Keyword.t) :: on_start```

Parenthesis are also added to aliases with a variable section ```One.x().Three```, which may or may not be acceptable. There doesn't appear to be anything in the context to differentiate ```Mix.env``` from ```One.x.Three```, so it gets formatted as ```One.x().Three```. You may see something I missed.


## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.