### PR TITLE
Render parens on zero arity fun definitions #51

### DIFF
--- a/lib/exfmt/ast.ex
+++ b/lib/exfmt/ast.ex
@@ -25,6 +25,8 @@ defmodule Exfmt.Ast do
 
 
   def eq?({x_name, _, x_args}, {y_name, _, y_args}) do
+    x_args = convert_nil_args(x_args)
+    y_args = convert_nil_args(y_args)
     eq?(x_name, y_name) and eq?(x_args, y_args)
   end
 
@@ -40,6 +42,14 @@ defmodule Exfmt.Ast do
     x == y
   end
 
+  # converts nil args to empty list
+  defp convert_nil_args([{_, _, nil}, _] = args) do
+    List.replace_at(args, 0, put_elem(List.first(args), 2, []))
+  end
+
+  defp convert_nil_args(args) do
+    args
+  end
 
   @doc """
   Introduces empty lines to group related expressions.

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -344,7 +344,7 @@ defmodule Exfmt.Integration.BasicsTest do
       end
     """
     assert_format """
-    defp read_source do
+    defp read_source() do
       source = case :ok do
           :ok ->
             :ok

--- a/test/exfmt/integration/comments_test.exs
+++ b/test/exfmt/integration/comments_test.exs
@@ -68,14 +68,14 @@ defmodule Exfmt.Integration.CommentsTest do
     # one a
     # one b
     # one c
-    defp one do
+    defp one() do
       1
     end
     """ ~> """
     # one a
     # one b
     # one c
-    defp one do
+    defp one() do
       1
     end
     """

--- a/test/exfmt/integration/def_test.exs
+++ b/test/exfmt/integration/def_test.exs
@@ -23,6 +23,66 @@ defmodule Exfmt.Integration.DefTest do
     """
   end
 
+  test "def with zero arity" do
+    """
+    def one do
+      1
+    end
+    """ ~> """
+    def one() do
+      1
+    end
+    """
+  end
+
+  test "defp with zero arity" do
+    """
+    defp one do
+      1
+    end
+    """ ~> """
+    defp one() do
+      1
+    end
+    """
+  end
+
+  test "defmacro with zero arity" do
+    """
+    defmacro one do
+      1
+    end
+    """ ~> """
+    defmacro one() do
+      1
+    end
+    """
+  end
+
+  test "defmacrop with zero arity" do
+    """
+    defmacrop one do
+      1
+    end
+    """ ~> """
+    defmacrop one() do
+      1
+    end
+    """
+  end
+
+  test "defdelegate with zero arity" do
+    """
+    defdelegate one do
+      1
+    end
+    """ ~> """
+    defdelegate one() do
+      1
+    end
+    """
+  end
+
   test "def spacing" do
     assert_format """
     def one(1) do
@@ -47,12 +107,12 @@ defmodule Exfmt.Integration.DefTest do
   test "def spacing with comments" do
     assert_format """
     # One comment
-    def one do
+    def one() do
       2
     end
 
 
-    def two do
+    def two() do
       1
     end
     """

--- a/test/exfmt/integration/module_test.exs
+++ b/test/exfmt/integration/module_test.exs
@@ -5,12 +5,12 @@ defmodule Exfmt.Integration.ModuleTest do
   test "multiple functions" do
     assert_format """
     defmodule App do
-      def run do
+      def run() do
         :ok
       end
 
 
-      def stop do
+      def stop() do
         :ok
       end
     end
@@ -35,13 +35,13 @@ defmodule Exfmt.Integration.ModuleTest do
     assert_format """
     defmodule App do
       @doc false
-      def run do
+      def run() do
         :ok
       end
 
 
       @doc false
-      def stop do
+      def stop() do
         :ok
       end
     end
@@ -57,7 +57,7 @@ defmodule Exfmt.Integration.ModuleTest do
       require Bar
 
       @doc false
-      def run do
+      def run() do
         :ok
       end
     end
@@ -71,7 +71,7 @@ defmodule Exfmt.Integration.ModuleTest do
       @bar 2
 
       @doc false
-      def run do
+      def run() do
         :ok
       end
     end
@@ -87,7 +87,7 @@ defmodule Exfmt.Integration.ModuleTest do
       @bar 2
 
       @doc false
-      def run do
+      def run() do
         :ok
       end
     end


### PR DESCRIPTION
## Description

This pull request renders parentheses on zero arity function definitions. 

**Note, I came across an surprising complication while implementing this. Let me know what you think about the solution.**

The semantic tests in ```Semantic.ExfmtProjectTest``` were failing when parentheses were added to zero arity function definitions. This is because the AST produced by a zero arity function definition without parentheses:

```elixir
def foo do
  true
end
```

```elixir
{:def, [line: 1], [{:foo, [line: 1], nil}, [do: true]]}
```

differs slightly from the same function definition with parentheses:
 
```elixir
def foo() do
  true
end
```

```elixir
{:def, [line: 1], [{: foo, [line: 1], []}, [do: true]]}
```

Semantically they're the same, but the equality check was getting confused by the fact that the first has ```nil``` for args and the second has ```[]```.  The ```Exfmt.Ast``` was modified to covert ```nil``` args to empty lists ```[]``` so the equality check would be satisfied.

I tested this pull request on a few dozen files in the main Elixir repository and didn't encounter any problems. Let me know your thoughts.

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.