### PR TITLE
Indent assignment expressions with multi-line pipelines #65

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -244,6 +244,15 @@ defmodule Exfmt.Ast.ToAlgebra do
             [lhs, " = ", rhs]
             |> concat()
             |> group()
+
+          # When assigning the result of a multi-line expression,
+          # begin the expression on a new line
+          {:|>, _, [_, {_, _, _}]} ->
+            [lhs, " =", line(), rhs]
+            |> concat()
+            |> group()
+            |> nest(2)
+
           _ ->
             [lhs, " ", to_string(op), break(), rhs]
             |> concat()

--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -245,9 +245,15 @@ defmodule Exfmt.Ast.ToAlgebra do
             |> concat()
             |> group()
 
-          # When assigning the result of a multi-line expression,
-          # begin the expression on a new line
+          # assignment of multi-line pipeline expression
           {:|>, _, [_, {_, _, _}]} ->
+            [lhs, " =", line(), rhs]
+            |> concat()
+            |> group()
+            |> nest(2)
+
+          # assignment of multi-line case expression
+          {:case, _, [_, [do: _]]} ->
             [lhs, " =", line(), rhs]
             |> concat()
             |> group()

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -330,6 +330,18 @@ defmodule Exfmt.Integration.BasicsTest do
     """
   end
 
+  test "infix assignment with multiline pipelines" do
+    """
+    sanitized = string |> String.downcase() |> String.strip()
+    """ ~>
+    """
+    sanitized =
+      string
+      |> String.downcase()
+      |> String.strip()
+    """
+  end
+
   test "direct call to __aliases__/1" do
     assert_format """
     __aliases__(args)

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -350,14 +350,16 @@ defmodule Exfmt.Integration.BasicsTest do
 
   test "assignment with case" do
     assert_format """
-    x = case y do
+    x =
+      case y do
         :ok ->
           :ok
       end
     """
     assert_format """
     defp read_source do
-      source = case :ok do
+      source =
+        case :ok do
           :ok ->
             :ok
         end


### PR DESCRIPTION
## Description

Per the [style guide](https://github.com/lexmag/elixir-style-guide#multi-line-expr-assignment), when assigning the result of a multi-line expression, the expression should begin on a new line. 

```elixir
# Bad
{found, not_found} = files
                     |> Enum.map(&Path.expand(&1, path))
                     |> Enum.partition(&File.exists?/1)

prefix = case base do
           :binary -> "0b"
           :octal -> "0o"
           :hex -> "0x"
         end

# Good
{found, not_found} =
  files
  |> Enum.map(&Path.expand(&1, path))
  |> Enum.partition(&File.exists?/1)

prefix =
  case base do
    :binary -> "0b"
    :octal -> "0o"
    :hex -> "0x"
  end
```

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.