### PR TITLE
Add --maxwidth switch to command line interface

### DIFF
--- a/lib/exfmt/cli.ex
+++ b/lib/exfmt/cli.ex
@@ -24,9 +24,9 @@ defmodule Exfmt.Cli do
   end
 
 
-  defp parse_argv(args) do
-    opts =[check: :boolean, unsafe: :boolean, stdin: :boolean]
-    {switches, args, _errors} = OptionParser.parse(args, strict: opts)
+  defp parse_argv(argv) do
+    opts = [check: :boolean, maxwidth: :integer, stdin: :boolean, unsafe: :boolean]
+    {switches, args, _errors} = OptionParser.parse(argv, strict: opts)
     {Enum.into(switches, %{}), args}
   end
 
@@ -47,12 +47,21 @@ defmodule Exfmt.Cli do
     {switches, args, File.read(path)}
   end
 
+
   defp format_source({%{check: true}, _args, {:ok, source}}) do
     Exfmt.check source
   end
 
+  defp format_source({%{unsafe: true, maxwidth: width}, _args, {:ok, source}}) do
+    Exfmt.unsafe_format source, width
+  end
+
   defp format_source({%{unsafe: true}, _args, {:ok, source}}) do
     Exfmt.unsafe_format source
+  end
+
+  defp format_source({%{maxwidth: width}, _args, {:ok, source}}) do
+    Exfmt.format source, width
   end
 
   defp format_source({_switches, _args, {:ok, source}}) do

--- a/test/exfmt/cli_test.exs
+++ b/test/exfmt/cli_test.exs
@@ -62,6 +62,11 @@ defmodule Exfmt.CliTest do
       assert result.exit_code == 1
       assert result.stderr =~ "Error: syntax error before"
     end
+
+    test "maxwidth switch" do
+      result = Exfmt.Cli.run(["--maxwidth", "40", "priv/examples/ok.ex"])
+      assert result.stdout == ":ok\n"
+    end
   end
 
   def provide_stdin(string) do


### PR DESCRIPTION
## Description

This pull request adds ```--maxwidth``` to the CLI options. When given, the value is passed to ```Exfmt.format``` and ```Exfmt.unsafe_format``` as the ```max_width``` argument.

This option allows editor plugins to respect user's preferred line width settings.


## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.