### PR TITLE
Indent and align when guard clauses

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -266,6 +266,10 @@ defmodule Exfmt.Ast.ToAlgebra do
             |> nest(2)
         end
 
+      {:when, _} ->
+        [lhs, break(), "when ", rhs]
+        |> concat()
+
       _ ->
         [lhs, " ", to_string(op), break(), rhs]
         |> concat()
@@ -592,10 +596,11 @@ defmodule Exfmt.Ast.ToAlgebra do
   defp args_to_algebra([{:when, _, args}], ctx, opts) do
     new_ctx = Context.push_stack(ctx, :when)
     {call_args, [guard]} = Enum.split(args, -1)
-    args_doc = args_to_algebra(call_args, ctx, opts)
-    guard_doc = to_algebra(guard, new_ctx)
-    [args_doc, group(nest(glue("", group(space("when", guard_doc))), 1))]
-    |> concat()
+    guard_doc = space("when", to_algebra(guard, new_ctx))
+    args_to_algebra(call_args, ctx, opts)
+    |> glue(guard_doc)
+    |> nest(1)
+    |> group()
   end
 
   defp args_to_algebra(args, ctx, opts) do

--- a/test/exfmt/integration/def_test.exs
+++ b/test/exfmt/integration/def_test.exs
@@ -11,14 +11,12 @@ defmodule Exfmt.Integration.DefTest do
   end
 
   test "def with long guard" do
-    """
-    def one?(x) when x in [:one, "one", 1, "1"] do
-      true
-    end
-    """ ~> """
-    def one?(x)
-        when x in [:one, "one", 1, "1"] do
-      true
+    assert_format """
+    defp valid?(left, doc, right)
+         when is_doc(left)
+         when is_doc(doc)
+         when is_doc(right) do
+      :ok
     end
     """
   end


### PR DESCRIPTION
# Description

This pull request formats guards with multiple `when` expressions.

Per the [style guide](https://github.com/lexmag/elixir-style-guide#binary-ops-indentation), guards with multiple `when` expressions should have the expressions rendered at the beginning of the line and be indented at the same level as their left-hand side.

For example:

```elixir
defp valid_identifier_char?(character) when character in ?a..?z
  when character in ?A..?Z when character in ?0..?9 when character == ?_ do
  true
end
```

should be formatted:

```elixir
defp valid_identifier_char?(character)
     when character in ?a..?z
     when character in ?A..?Z
     when character in ?0..?9
     when character == ?_ do
  true
end
```


## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
