### PR TITLE
Hold opening list bracket next to assignment

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -245,6 +245,12 @@ defmodule Exfmt.Ast.ToAlgebra do
             |> concat()
             |> group()
 
+          # hold opening list bracket next to assignment
+          [_ | _] ->
+            [lhs, " = ", rhs]
+            |> concat()
+            |> group()
+
           # assignment of multi-line pipeline expression
           {:|>, _, [_, {_, _, _}]} ->
             [lhs, " =", line(), rhs]

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -105,6 +105,14 @@ defmodule Exfmt.Integration.BasicsTest do
       :elem_four,
     ]
     """
+    assert_format """
+    options = [
+      :elem_one,
+      :elem_two,
+      :elem_three,
+      :elem_four,
+    ]
+    """
   end
 
   test "tuples" do


### PR DESCRIPTION
## Description

This pull request ensures that the opening bracket of a multiline list assignment always remains next to the assignment, while wrapping the closing bracket to the level of the assignment. This is essentially the same behavior that was added for maps in #46.

For example,

```elixir
options =
  [
    :alpha,
    :beta,
    :gamma,
    :delta,
    :epsilon,
    :zeta,
    :eta,
  ]
````

will be formatted:

```elixir
options = [
  :alpha,
  :beta,
  :gamma,
  :delta,
  :epsilon,
  :zeta,
  :eta,
]
````

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.