### PR TITLE
Format complex guards with multiple boolean expressions

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -276,6 +276,21 @@ defmodule Exfmt.Ast.ToAlgebra do
         [lhs, break(), "when ", rhs]
         |> concat()
 
+      {:and, _} ->
+        [lhs, " and", nest(concat(break(), rhs), 5)]
+        |> concat()
+        |> group()
+
+      {:or, _} ->
+        [lhs, " or", nest(concat(break(), rhs), 5)]
+        |> concat()
+        |> group()
+
+      {:in, _} ->
+        [lhs, " in ", rhs]
+        |> concat()
+        |> group()
+
       _ ->
         [lhs, " ", to_string(op), break(), rhs]
         |> concat()

--- a/test/exfmt/integration/def_test.exs
+++ b/test/exfmt/integration/def_test.exs
@@ -19,6 +19,21 @@ defmodule Exfmt.Integration.DefTest do
       :ok
     end
     """
+    assert_format """
+    defp valid_operation?(op, args, ref)
+         when is_atom(op) and
+              not op in @unary_ops and
+              not op in @binary_ops
+         when is_map(args) and
+              map_size(map) > 2
+         when is_list(ref) or
+              not is_nil(level) or
+              is_float(args) or
+              is_integer(ref) or
+              rem(ref, 2) == 0 do
+      true
+    end
+    """
   end
 
   test "def spacing" do


### PR DESCRIPTION
## Description

This pull request adds formatting support for complex guards with multiple boolean predicates as shown in the [style guide](https://github.com/lexmag/elixir-style-guide#indentation).

For example,

```elixir
defp valid_operation?(operation, args, ref) when is_atom(operation) and not operation in @unary_ops and
  not operation in @binary_ops when is_map(args) and map_size(map) > 2 when is_list(ref) or not is_nil(ref) or is_float(args) or is_integer(ref) and rem(ref, 2) == 0 do
  true
end
```

will be formatted:

```elixir
defp valid_operation?(operation, args, ref)
     when is_atom(operation) and not operation in @unary_ops and
          not operation in @binary_ops
     when is_map(args) and map_size(map) > 2
     when is_list(ref) or not is_nil(ref) or is_float(args) or
          is_integer(ref) and rem(ref, 2) == 0 do
  true
end
```

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
