### PR TITLE
Nest wrapped typespec statements

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -210,7 +210,7 @@ defmodule Exfmt.Ast.ToAlgebra do
     rhs_ctx = Context.push_stack(ctx, :spec_rhs)
     lhs = to_algebra(fun, lhs_ctx)
     rhs = to_algebra(result, rhs_ctx)
-    [lhs, break(), ":: ", group(rhs)]
+    [lhs, nest(concat(break(), group(concat(":: ", rhs))), 2)]
     |> concat()
   end
 

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -14,7 +14,7 @@ defmodule Exfmt.Integration.TypespecTest do
     @spec run(String.t) :: atom | String.t | :hello
     """ ~> """
     @spec run(String.t)
-    :: atom | String.t | :hello
+      :: atom | String.t | :hello
     """
     """
     @spec start_link(module(), term(number), Keyword.t()) :: on_start()
@@ -22,7 +22,7 @@ defmodule Exfmt.Integration.TypespecTest do
     @spec start_link(module(),
                      term(number),
                      Keyword.t)
-    :: on_start()
+      :: on_start()
     """
     assert_format """
     @spec break() :: doc_break()
@@ -34,7 +34,17 @@ defmodule Exfmt.Integration.TypespecTest do
     @spec run(String.t) :: atom | String.t | :hello | :world
     """ ~> """
     @spec run(String.t)
-    :: atom | String.t | :hello | :world
+      :: atom | String.t | :hello | :world
+    """
+    """
+    @spec run(String.t, term, opts) :: atom | String.t | :hello | :world | number
+    """ ~> """
+    @spec run(String.t, term, opts)
+      :: atom
+      | String.t
+      | :hello
+      | :world
+      | number
     """
   end
 


### PR DESCRIPTION
## Description

This pull request nests wrapped typespec statements.

For example,

```elixir
@spec format(String.t,)
:: {:ok, String.t} | SyntaxError.t | SemanticsError.t
```

is formatted:

```elixir
@spec format(String.t,)
  :: {:ok, String.t} | SyntaxError.t | SemanticsError.t
```

and

```elixir
@spec async_stream(Enumerable.t, String.t, term, opts)
:: SyntaxError.t
| SemanticsError.t
| InterruptibleIOError.t
| ErlangError.t
| ParseError.t
```

is formatted:

```elixir
@spec async_stream(Enumerable.t, String.t, term, opts)
  :: SyntaxError.t
  | SemanticsError.t
  | InterruptibleIOError.t
  | ErlangError.t
  | ParseError.t
```

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.