### PR TITLE
Format struct assignments

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -115,11 +115,9 @@ defmodule Exfmt.Ast.ToAlgebra do
   def to_algebra({:%, _, [name, {:%{}, _, args}]}, ctx) do
     name_ctx = Context.push_stack(ctx, :struct_name)
     name = struct_name_to_algebra(name, name_ctx)
-    body_doc =
-      args
-      |> map_body_to_algebra(ctx)
-      |> nest(:current)
-    surround(concat(["%", name, "{"]), body_doc, "}")
+    body_doc = map_body_to_algebra(args, ctx)
+    ["%", name, "{", nest(concat([break(""), body_doc]), 2), break(""), "}"]
+    |> concat()
     |> group()
   end
 
@@ -244,6 +242,12 @@ defmodule Exfmt.Ast.ToAlgebra do
           # even when space constraints force a line break
           {:%{}, _, _} ->
             [lhs, " = ", rhs]
+            |> concat()
+            |> group()
+
+          # structs
+          {:%, _, [{:__aliases__, _, _}, {:%{}, _, _}]} ->
+            [lhs, " =", nest(concat(break(), rhs), 2)]
             |> concat()
             |> group()
 

--- a/test/exfmt/integration/map_test.exs
+++ b/test/exfmt/integration/map_test.exs
@@ -61,11 +61,46 @@ defmodule Exfmt.Integration.MapTest do
     """
     %LongerNamePerson{timmy | name: "Timmy", age: 1}
     """ ~> """
-    %LongerNamePerson{timmy |
-                      name: "Timmy",
-                      age: 1}
+    %LongerNamePerson{
+      timmy |
+      name: "Timmy",
+      age: 1
+    }
     """
     assert_format "%Inspect.Opts{}\n"
+  end
+
+  test "struct assignments" do
+    assert_format "datetime = %NaiveDateTime{year: 2017}\n"
+    """
+    datetime = %NaiveDateTime{calendar: Calendar.ISO}
+    """ ~> """
+    datetime =
+      %NaiveDateTime{calendar: Calendar.ISO}
+    """
+    """
+    %NaiveDateTime{calendar: Calendar.ISO} = datetime_struct
+    """ ~> """
+    %NaiveDateTime{calendar: Calendar.ISO} =
+      datetime_struct
+    """
+    """
+    %NaiveDateTime{calendar: calendar, day: day, month: month, year: year } =
+    %NaiveDateTime{ calendar: Calendar.ISO, day: 1, month: 1, year: 2017}
+    """ ~> """
+    %NaiveDateTime{
+      calendar: calendar,
+      day: day,
+      month: month,
+      year: year
+    } =
+      %NaiveDateTime{
+        calendar: Calendar.ISO,
+        day: 1,
+        month: 1,
+        year: 2017
+      }
+    """
   end
 
   test "__MODULE__ structs" do


### PR DESCRIPTION
## Description

**Any feedback on this is welcome.**

This pull request formats struct assignments. It holds structs and their fields together as much as possible, only breaking when neither the right not left hand side fits on one line.

Below are examples of how it addresses the four possible scenarios:

I. Both right and left hand sides fit:

```elixir
datetime = %NaiveDateTime{calendar: Calendar.ISO, year: 2017}
```

II. Left hand side fits, but right doesn't:

```elixir
datetime =
  %NaiveDateTime{calendar: Calendar.ISO, day: 1, month: 12, year: 2017}
```

III. Right hand side fits, but left doesn't:

```elixir
%NaiveDateTime{calendar: Calendar.ISO, day: 1, month: 12, year: 2017} =
  datetime_struct
```

IV. Neither right nor left hand side fits:

```elixir
%NaiveDateTime{
  calendar: calendar,
  day: day,
  hour: hour,
  microsecond: microsecond,
  minute: minute,
  month: month,
  second: second,
  year: year} = %NaiveDateTime{
    calendar: Calendar.ISO,
    day: 1,
    hour: 23,
    microsecond: {0, 0},
    minute: 59,
    month: 1,
    second: 59,
    year: 2017
  }
```

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.