### PR TITLE
Fix typespec regression causing unnecessary wrapping and add tests

### DIFF
--- a/lib/exfmt/ast/to_algebra.ex
+++ b/lib/exfmt/ast/to_algebra.ex
@@ -210,7 +210,7 @@ defmodule Exfmt.Ast.ToAlgebra do
     rhs_ctx = Context.push_stack(ctx, :spec_rhs)
     lhs = to_algebra(fun, lhs_ctx)
     rhs = to_algebra(result, rhs_ctx)
-    [lhs, nest(concat(break(), group(concat(":: ", rhs))), 2)]
+    [lhs, nest(group(concat([break(), ":: ", group(rhs)])), 2)]
     |> concat()
   end
 

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -11,12 +11,6 @@ defmodule Exfmt.Integration.TypespecTest do
     @spec run(String.t, [tern]) :: atom
     """
     """
-    @spec run(String.t) :: atom | String.t | :hello
-    """ ~> """
-    @spec run(String.t)
-      :: atom | String.t | :hello
-    """
-    """
     @spec start_link(module(), term(number), Keyword.t()) :: on_start()
     """ ~> """
     @spec start_link(module(),
@@ -29,22 +23,37 @@ defmodule Exfmt.Integration.TypespecTest do
     """
   end
 
-  test "@spec 2" do
-    """
-    @spec run(String.t) :: atom | String.t | :hello | :world
-    """ ~> """
+  test "@spec wrapping" do
+    # right side too long
+    assert_format """
     @spec run(String.t)
-      :: atom | String.t | :hello | :world
-    """
-    """
-    @spec run(String.t, term, opts) :: atom | String.t | :hello | :world | number
-    """ ~> """
-    @spec run(String.t, term, opts)
       :: atom
-      | String.t
-      | :hello
-      | :world
-      | number
+      | atom
+      | atom
+      | atom
+      | atom
+      | atom
+    """
+    # left side too long
+    assert_format """
+    @spec run(String.t,
+              term,
+              [meta],
+              options)
+      :: atom | atom | atom | atom | atom
+    """
+    # right and left sides too long
+    assert_format """
+    @spec run(String.t,
+              term,
+              [meta],
+              options)
+      :: atom
+      | atom
+      | atom
+      | atom
+      | atom
+      | atom
     """
   end
 


### PR DESCRIPTION
## Description

This pull request fixes a regressions in typespec formatting introduced in #73 that caused all typespecs statements to have line breaks after the ```::``` operator. It also includes new test cases that cover the four different line break scenarios.

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.