### PR TITLE
Nest multiline call arguments one level

### DIFF
--- a/lib/exfmt/algebra.ex
+++ b/lib/exfmt/algebra.ex
@@ -220,20 +220,20 @@ defmodule Exfmt.Algebra do
       "[1,\n 2,\n 3,\n 4,\n 5]"
 
   """
-  def surround_many(open, args, close, fun)
+  def surround_many(open, args, close, fun, opts \\ [nest: true])
 
-  def surround_many(open, [], close, _) do
+  def surround_many(open, [], close, _, _) do
     concat(open, close)
   end
 
-  def surround_many(open, args, close, fun) do
+  def surround_many(open, args, close, fun, opts) do
     args_doc =
       args
       |> Enum.map(fun)
       |> Enum.reduce(fn(e, acc) ->
         glue(concat(acc, ","), e)
       end)
-    surround(open, args_doc, close)
+    surround(open, args_doc, close, opts)
   end
 
 
@@ -393,9 +393,15 @@ defmodule Exfmt.Algebra do
       iex> Inspect.Algebra.format(doc, 3)
       ["[", "a", "\n ", "b", "]"]
   """
-  @spec surround(t, t, t) :: t
-  def surround(left, doc, right) when is_doc(left) and is_doc(doc) and is_doc(right) do
-    group(concat(left, concat(nest(doc, @nesting), right)))
+  @spec surround(t, t, t, Keyword.t) :: t
+  def surround(left, doc, right, opts \\ [nest: true])
+  def surround(left, doc, right, opts)
+      when is_doc(left) and is_doc(doc) and is_doc(right) do
+    if opts[:nest] do
+      concat(left, concat(nest(doc, @nesting), right))
+    else
+      concat(left, concat(doc, right))
+    end
   end
 
   #

--- a/test/exfmt/integration/basics_test.exs
+++ b/test/exfmt/integration/basics_test.exs
@@ -245,6 +245,19 @@ defmodule Exfmt.Integration.BasicsTest do
     """
   end
 
+  test "pipe |> argument nesting" do
+    assert_format """
+    valid =
+      changeset
+      |> split_emails
+      |> Changeset.validate_format(
+           field,
+           regex,
+           message: invalid_email_msg
+         )
+    """
+  end
+
   test "case" do
     """
     case number do

--- a/test/exfmt/integration/def_test.exs
+++ b/test/exfmt/integration/def_test.exs
@@ -86,4 +86,35 @@ defmodule Exfmt.Integration.DefTest do
     end
     """
   end
+
+  test "def with many arguments" do
+    assert_format """
+    def generate_buffer(
+          start_expr,
+          start_line,
+          mark,
+          chars,
+          buffer
+        ) do
+      :ok
+    end
+    """
+  end
+
+  test "def with many arguments and complex guard" do
+    assert_format """
+    def generate_buffer(
+          start_expr,
+          start_line,
+          mark,
+          chars,
+          buffer
+        )
+        when is_atom(mark) and
+             not op in @unary_ops
+        when is_atom(mark) do
+      :ok
+    end
+    """
+  end
 end

--- a/test/exfmt/integration/module_test.exs
+++ b/test/exfmt/integration/module_test.exs
@@ -142,6 +142,28 @@ defmodule Exfmt.Integration.ModuleTest do
   end
 
   test "grouping use, import, alias, require calls" do
+    """
+    use GenServer
+    use PortMapper
+    import Bitwise
+    import Kernel, except: [length: 1]
+    alias Mix.Utils
+    alias MapSet, as: Set
+    require Logger
+    require Printer
+    """ ~> """
+    use GenServer
+    use PortMapper
+
+    import Bitwise
+    import Kernel, except: [length: 1]
+
+    alias Mix.Utils
+    alias MapSet, as: Set
+
+    require Logger
+    require Printer
+    """
     assert_format """
     defmodule App do
       use GenServer

--- a/test/exfmt/integration/typespec_test.exs
+++ b/test/exfmt/integration/typespec_test.exs
@@ -13,9 +13,11 @@ defmodule Exfmt.Integration.TypespecTest do
     """
     @spec start_link(module(), term(number), Keyword.t()) :: on_start()
     """ ~> """
-    @spec start_link(module(),
-                     term(number),
-                     Keyword.t)
+    @spec start_link(
+        module(),
+        term(number),
+        Keyword.t
+      )
       :: on_start()
     """
     assert_format """
@@ -36,18 +38,22 @@ defmodule Exfmt.Integration.TypespecTest do
     """
     # left side too long
     assert_format """
-    @spec run(String.t,
-              term,
-              [meta],
-              options)
+    @spec run(
+        String.t,
+        term,
+        [meta],
+        options
+      )
       :: atom | atom | atom | atom | atom
     """
     # right and left sides too long
     assert_format """
-    @spec run(String.t,
-              term,
-              [meta],
-              options)
+    @spec run(
+        String.t,
+        term,
+        [meta],
+        options
+      )
       :: atom
       | atom
       | atom


### PR DESCRIPTION
## Description

This pull request implements #76. 

Note, I needed to add an ```opts``` argument to ```Exfmt.Algebra.surround_many``` and ```Exfmt.Algebra.surround```. It suppresses automatic doc nesting when ```opts[:nest] == false```.

## Checklist

- [x] The change has been discussed in a GitHub issue.
- [x] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.