### PR TITLE
Add Escript building options

### DIFF
--- a/lib/exfmt/escript.ex
+++ b/lib/exfmt/escript.ex
@@ -1,0 +1,5 @@
+defmodule Exfmt.Escript do
+  def main(argv) do
+    Mix.Tasks.Exfmt.run argv
+  end
+end

--- a/lib/mix/tasks/exfmt.ex
+++ b/lib/mix/tasks/exfmt.ex
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Exfmt do
 
   def run(argv) do
     argv
-    |> Cli.run
+    |> Cli.run()
     |> execute_output()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,12 +21,13 @@ defmodule Exfmt.Mixfile do
         links: %{"GitHub" => "https://github.com/lpil/exfmt"},
         files: ~w(LICENCE README.md lib mix.exs),
       ],
+      escript: [main_module: Exfmt.Escript],
     ]
   end
 
 
   def application do
-    [extra_applications: []]
+    [extra_applications: [:mix]]
   end
 
 


### PR DESCRIPTION
## Description
Allows building an Escript version of Exfmt by running `mix
escript.build`.

This Escript wraps the Elixir version that this command is run on.

As discussed in #71 


## Checklist

- [X] The change has been discussed in a GitHub issue.
- [ ] There are tests for the new functionality.
- [X] I agree to adhere to the code of conduct.
