### PR TITLE
Fix preserve_comments

### DIFF
--- a/lib/exfmt/comment.ex
+++ b/lib/exfmt/comment.ex
@@ -31,7 +31,7 @@ defmodule Exfmt.Comment do
   end
 
 
-  def tokenize(src) do
+  defp tokenize(src) do
     pid = spawn_link(fn -> store([]) end)
     src
     |> String.to_charlist()
@@ -43,7 +43,7 @@ defmodule Exfmt.Comment do
     end
   end
 
-  def send_comment(pid) do
+  defp send_comment(pid) do
     fn (line, column, _tokens, comment, _rest) ->
         length = length(comment)
         comment_token = {:comment, {line, {column, column + length}, nil}, comment}
@@ -51,7 +51,7 @@ defmodule Exfmt.Comment do
     end
   end
 
-  def store(tokens) do
+  defp store(tokens) do
     receive do
       {:put, token} ->
         store([token | tokens])

--- a/test/exfmt/comment_test.exs
+++ b/test/exfmt/comment_test.exs
@@ -66,9 +66,6 @@ defmodule Exfmt.CommentTest do
       assert extract_comments(code) == {:ok, [{:"#", [line: 4], [" Hi!"]}]}
     end
 
-    #
-    # FIXME: Comments inside interpolation are currently discarded.
-    #
     test "comment in interp in string" do
       code = ~S(
       """
@@ -76,7 +73,7 @@ defmodule Exfmt.CommentTest do
       }
       """
       )
-      assert extract_comments(code) == {:ok, []}
+      assert extract_comments(code) == {:ok, [{:"#", [line: 3], [" A comment!"]}]}
     end
 
     test "\" char literals" do


### PR DESCRIPTION
The cause is this commits: https://github.com/elixir-lang/elixir/commit/455c2c3

The above commit changed to a method to collect comments using side effects.

I implemented method to collect comment using [state process](https://elixir-lang.org/getting-started/processes.html#state).

(discussed a little on https://github.com/lpil/exfmt/pull/90)

## Description

This pull request fixes.

## Checklist

- [ ] The change has been discussed in a GitHub issue.
- [ ] There are tests for the new functionality.
- [x] I agree to adhere to the code of conduct.
